### PR TITLE
Phase 5: Reaper for stalled job recovery

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,5 +35,8 @@ export { MemoryStorage } from './storage/memory.ts'
 // Queue
 export { Queue } from './queue.ts'
 
+// Reaper
+export { Reaper } from './reaper.ts'
+
 // Utils
 export { generateId, contentId } from './utils/id.ts'

--- a/src/reaper.ts
+++ b/src/reaper.ts
@@ -1,0 +1,279 @@
+import { EventEmitter } from 'node:events'
+import type { Storage } from './storage/types.ts'
+import type { Serde } from './serde/index.ts'
+import type { QueueMessage } from './types.ts'
+import { createJsonSerde } from './serde/index.ts'
+
+interface ReaperConfig<TPayload> {
+  storage: Storage
+  payloadSerde?: Serde<TPayload>
+  visibilityTimeout?: number
+  checkInterval?: number
+}
+
+interface ReaperEvents {
+  error: [error: Error]
+  stalled: [id: string]
+}
+
+/**
+ * Parse job state string into components
+ */
+function parseState (state: string): { status: string, timestamp: number, workerId?: string } {
+  const parts = state.split(':')
+  return {
+    status: parts[0],
+    timestamp: parseInt(parts[1], 10),
+    workerId: parts[2]
+  }
+}
+
+/**
+ * Reaper monitors for stalled jobs and requeues them.
+ *
+ * A job is considered stalled if it has been in "processing" state
+ * longer than the visibility timeout.
+ */
+export class Reaper<TPayload> extends EventEmitter<ReaperEvents> {
+  #storage: Storage
+  #payloadSerde: Serde<TPayload>
+  #visibilityTimeout: number
+  #checkInterval: number
+
+  #running = false
+  #unsubscribe: (() => Promise<void>) | null = null
+  #checkIntervalTimer: ReturnType<typeof setInterval> | null = null
+  #processingTimers: Map<string, ReturnType<typeof setTimeout>> = new Map()
+
+  constructor (config: ReaperConfig<TPayload>) {
+    super()
+    this.#storage = config.storage
+    this.#payloadSerde = config.payloadSerde ?? createJsonSerde<TPayload>()
+    this.#visibilityTimeout = config.visibilityTimeout ?? 30000
+    this.#checkInterval = config.checkInterval ?? 60000
+  }
+
+  /**
+   * Start the reaper
+   */
+  async start (): Promise<void> {
+    if (this.#running) return
+
+    this.#running = true
+
+    // Subscribe to job events
+    this.#unsubscribe = await this.#storage.subscribeToEvents((id, event) => {
+      this.#handleEvent(id, event)
+    })
+
+    // Do an initial check for stalled jobs
+    await this.#checkStalledJobs()
+
+    // Start periodic check interval
+    this.#checkIntervalTimer = setInterval(() => {
+      this.#checkStalledJobs().catch((err) => {
+        this.emit('error', err)
+      })
+    }, this.#checkInterval)
+  }
+
+  /**
+   * Stop the reaper gracefully
+   */
+  async stop (): Promise<void> {
+    if (!this.#running) return
+
+    this.#running = false
+
+    // Clear check interval
+    if (this.#checkIntervalTimer) {
+      clearInterval(this.#checkIntervalTimer)
+      this.#checkIntervalTimer = null
+    }
+
+    // Clear all processing timers
+    for (const timer of this.#processingTimers.values()) {
+      clearTimeout(timer)
+    }
+    this.#processingTimers.clear()
+
+    // Unsubscribe from events
+    if (this.#unsubscribe) {
+      await this.#unsubscribe()
+      this.#unsubscribe = null
+    }
+  }
+
+  /**
+   * Handle a job state change event
+   */
+  #handleEvent (id: string, event: string): void {
+    if (event === 'processing') {
+      // Start a timer for this job
+      this.#startTimer(id)
+    } else if (event === 'completed' || event === 'failed' || event === 'cancelled') {
+      // Cancel any existing timer
+      this.#cancelTimer(id)
+    }
+  }
+
+  /**
+   * Start a visibility timeout timer for a job
+   */
+  #startTimer (id: string): void {
+    // Cancel any existing timer first
+    this.#cancelTimer(id)
+
+    const timer = setTimeout(() => {
+      this.#processingTimers.delete(id)
+      this.#checkJob(id).catch((err) => {
+        this.emit('error', err)
+      })
+    }, this.#visibilityTimeout)
+
+    this.#processingTimers.set(id, timer)
+  }
+
+  /**
+   * Cancel the timer for a job
+   */
+  #cancelTimer (id: string): void {
+    const timer = this.#processingTimers.get(id)
+    if (timer) {
+      clearTimeout(timer)
+      this.#processingTimers.delete(id)
+    }
+  }
+
+  /**
+   * Check if a job is stalled and requeue if necessary
+   */
+  async #checkJob (id: string): Promise<void> {
+    if (!this.#running) return
+
+    const state = await this.#storage.getJobState(id)
+    if (!state) return
+
+    const { status, timestamp, workerId } = parseState(state)
+
+    if (status !== 'processing') {
+      // Job is no longer processing, nothing to do
+      return
+    }
+
+    // Check if visibility timeout has elapsed
+    const elapsed = Date.now() - timestamp
+    if (elapsed < this.#visibilityTimeout) {
+      // Not yet stalled, restart timer for remaining time
+      const remaining = this.#visibilityTimeout - elapsed
+      const timer = setTimeout(() => {
+        this.#processingTimers.delete(id)
+        this.#checkJob(id).catch((err) => {
+          this.emit('error', err)
+        })
+      }, remaining)
+      this.#processingTimers.set(id, timer)
+      return
+    }
+
+    // Job is stalled - need to recover it
+    await this.#recoverStalledJob(id, workerId)
+  }
+
+  /**
+   * Recover a stalled job by requeueing it
+   */
+  async #recoverStalledJob (id: string, workerId?: string): Promise<void> {
+    if (!workerId) {
+      this.emit('error', new Error(`Cannot recover stalled job ${id}: no workerId in state`))
+      return
+    }
+
+    // Get the job from the worker's processing queue
+    const processingJobs = await this.#storage.getProcessingJobs(workerId)
+
+    // Find the message for this job
+    let jobMessage: Buffer | null = null
+    for (const message of processingJobs) {
+      try {
+        const queueMessage = this.#payloadSerde.deserialize(message) as unknown as QueueMessage<TPayload>
+        if (queueMessage.id === id) {
+          jobMessage = message
+          break
+        }
+      } catch {
+        // Ignore deserialization errors
+      }
+    }
+
+    if (!jobMessage) {
+      // Job not found in processing queue - it may have already been processed
+      // Clear the state to prevent future checks
+      return
+    }
+
+    // Requeue the job
+    await this.#storage.requeue(id, jobMessage, workerId)
+
+    // Update state to reflect retry
+    const queueMessage = this.#payloadSerde.deserialize(jobMessage) as unknown as QueueMessage<TPayload>
+    const newState = `failing:${Date.now()}:${queueMessage.attempts + 1}`
+    await this.#storage.setJobState(id, newState)
+
+    // Emit stalled event
+    this.emit('stalled', id)
+  }
+
+  /**
+   * Periodically check all workers' processing queues for stalled jobs
+   */
+  async #checkStalledJobs (): Promise<void> {
+    if (!this.#running) return
+
+    const workers = await this.#storage.getWorkers()
+
+    for (const workerId of workers) {
+      await this.#checkWorkerProcessingQueue(workerId)
+    }
+  }
+
+  /**
+   * Check a single worker's processing queue for stalled jobs
+   */
+  async #checkWorkerProcessingQueue (workerId: string): Promise<void> {
+    if (!this.#running) return
+
+    const processingJobs = await this.#storage.getProcessingJobs(workerId)
+
+    for (const message of processingJobs) {
+      try {
+        const queueMessage = this.#payloadSerde.deserialize(message) as unknown as QueueMessage<TPayload>
+        const state = await this.#storage.getJobState(queueMessage.id)
+
+        if (!state) continue
+
+        const { status, timestamp } = parseState(state)
+
+        if (status === 'processing') {
+          const elapsed = Date.now() - timestamp
+          if (elapsed >= this.#visibilityTimeout) {
+            // Job is stalled
+            await this.#recoverStalledJob(queueMessage.id, workerId)
+          } else if (!this.#processingTimers.has(queueMessage.id)) {
+            // Start a timer for remaining time
+            const remaining = this.#visibilityTimeout - elapsed
+            const timer = setTimeout(() => {
+              this.#processingTimers.delete(queueMessage.id)
+              this.#checkJob(queueMessage.id).catch((err) => {
+                this.emit('error', err)
+              })
+            }, remaining)
+            this.#processingTimers.set(queueMessage.id, timer)
+          }
+        }
+      } catch {
+        // Ignore deserialization errors
+      }
+    }
+  }
+}

--- a/test/reaper.test.ts
+++ b/test/reaper.test.ts
@@ -1,0 +1,342 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { once } from 'node:events'
+import { Queue, Reaper, MemoryStorage, type Job } from '../src/index.ts'
+
+describe('Reaper', () => {
+  let storage: MemoryStorage
+  let queue: Queue<{ value: number }, { result: number }>
+  let reaper: Reaper<{ value: number }>
+
+  beforeEach(async () => {
+    storage = new MemoryStorage()
+    queue = new Queue({
+      storage,
+      concurrency: 1,
+      maxRetries: 3,
+      resultTTL: 60000,
+      visibilityTimeout: 100 // Short timeout for testing
+    })
+    reaper = new Reaper({
+      storage,
+      visibilityTimeout: 100,
+      checkInterval: 50
+    })
+  })
+
+  afterEach(async () => {
+    await reaper.stop()
+    await queue.stop()
+    // Also disconnect storage directly in case it was connected without starting queue
+    await storage.disconnect()
+  })
+
+  describe('lifecycle', () => {
+    it('should start and stop', async () => {
+      await storage.connect()
+      await reaper.start()
+      await reaper.stop()
+    })
+
+    it('should handle multiple start calls', async () => {
+      await storage.connect()
+      await reaper.start()
+      await reaper.start()
+      await reaper.stop()
+    })
+
+    it('should handle multiple stop calls', async () => {
+      await storage.connect()
+      await reaper.start()
+      await reaper.stop()
+      await reaper.stop()
+    })
+  })
+
+  describe('stalled job detection', () => {
+    it('should detect and recover a stalled job', async () => {
+      // Use concurrency 2 so requeued job can be picked up while first is stalled
+      // Use longer visibility timeout than reaper to ensure reaper handles it, not consumer
+      const testQueue = new Queue<{ value: number }, { result: number }>({
+        storage,
+        concurrency: 2,
+        maxRetries: 3,
+        resultTTL: 60000,
+        visibilityTimeout: 500 // Longer than reaper's 100ms
+      })
+
+      let processCount = 0
+      let resolveFirstJob: (() => void) | null = null
+      const firstJobStarted = new Promise<void>(resolve => { resolveFirstJob = resolve })
+      let abortFirstHandler: (() => void) | undefined
+
+      testQueue.execute(async (job: Job<{ value: number }>) => {
+        processCount++
+        if (processCount === 1) {
+          resolveFirstJob!()
+          // First attempt: stall but allow cleanup via abort
+          await new Promise<void>((resolve) => {
+            abortFirstHandler = resolve
+            job.signal.addEventListener('abort', () => resolve())
+          })
+          throw new Error('Aborted for cleanup')
+        }
+        // Second attempt: complete normally
+        return { result: job.payload.value * 2 }
+      })
+
+      await testQueue.start()
+      await reaper.start()
+
+      // Enqueue a job
+      const resultPromise = testQueue.enqueueAndWait('job-1', { value: 21 }, { timeout: 5000 })
+
+      // Wait for first processing attempt
+      await firstJobStarted
+
+      // Wait for stall detection and requeue (reaper timeout 100ms + some buffer)
+      await sleep(200)
+
+      // Job should be reprocessed and complete
+      const result = await resultPromise
+
+      // Clean up - abort the stalled handler before stopping
+      abortFirstHandler?.()
+      await testQueue.stop()
+
+      assert.deepStrictEqual(result, { result: 42 })
+      assert.strictEqual(processCount, 2, 'Job should have been processed twice')
+    })
+
+    it('should emit stalled event when recovering a job', async () => {
+      // Use separate queue with longer visibility timeout so handler doesn't abort
+      const testQueue = new Queue<{ value: number }, { result: number }>({
+        storage,
+        concurrency: 1,
+        visibilityTimeout: 500 // Longer than reaper's 100ms
+      })
+
+      let resolveFirstJob: (() => void) | null = null
+      const firstJobStarted = new Promise<void>(resolve => { resolveFirstJob = resolve })
+      let abortHandler: (() => void) | undefined
+
+      testQueue.execute(async (job: Job<{ value: number }>) => {
+        resolveFirstJob!()
+        // Simulate stall but allow abort for cleanup
+        await new Promise<void>((resolve) => {
+          abortHandler = resolve
+          job.signal.addEventListener('abort', () => resolve())
+        })
+        return { result: 0 }
+      })
+
+      await testQueue.start()
+      await reaper.start()
+
+      // Start listening for stalled event
+      const stalledPromise = once(reaper, 'stalled')
+
+      // Enqueue a job (don't wait for result)
+      testQueue.enqueue('job-1', { value: 21 })
+
+      // Wait for processing to start
+      await firstJobStarted
+
+      // Wait for stalled event
+      const [stalledId] = await stalledPromise
+
+      // Clean up - abort the stalled handler so queue can stop
+      abortHandler?.()
+      await testQueue.stop()
+
+      assert.strictEqual(stalledId, 'job-1')
+    })
+
+    it('should not recover job that completes in time', async () => {
+      let processCount = 0
+
+      queue.execute(async (job: Job<{ value: number }>) => {
+        processCount++
+        // Complete quickly (before visibility timeout)
+        return { result: job.payload.value * 2 }
+      })
+
+      await queue.start()
+      await reaper.start()
+
+      const result = await queue.enqueueAndWait('job-1', { value: 21 }, { timeout: 5000 })
+
+      // Wait past visibility timeout
+      await sleep(150)
+
+      assert.deepStrictEqual(result, { result: 42 })
+      assert.strictEqual(processCount, 1, 'Job should only have been processed once')
+    })
+
+    it('should cancel timer when job completes', async () => {
+      queue.execute(async (job: Job<{ value: number }>) => {
+        // Complete quickly
+        return { result: job.payload.value * 2 }
+      })
+
+      await queue.start()
+      await reaper.start()
+
+      await queue.enqueueAndWait('job-1', { value: 21 }, { timeout: 5000 })
+
+      // Wait past visibility timeout - reaper should have cancelled the timer
+      await sleep(150)
+
+      // No stalled event should be emitted, no errors
+    })
+
+    it('should cancel timer when job fails', async () => {
+      queue.execute(async () => {
+        throw new Error('Job failed')
+      })
+
+      await queue.start()
+      await reaper.start()
+
+      // Job will fail after retries
+      await assert.rejects(
+        queue.enqueueAndWait('job-1', { value: 21 }, { timeout: 5000, maxAttempts: 1 }),
+        (err: Error) => err.name === 'JobFailedError'
+      )
+
+      // Wait past visibility timeout - reaper should have cancelled the timer
+      await sleep(150)
+
+      // No stalled event should be emitted for completed job
+    })
+  })
+
+  describe('periodic check', () => {
+    it('should detect stalled jobs on startup', async () => {
+      // Manually set up a "stalled" job state
+      await storage.connect()
+
+      const oldTimestamp = Date.now() - 200 // 200ms ago (past visibility timeout)
+
+      // Add job to worker's processing queue
+      const message = Buffer.from(JSON.stringify({
+        id: 'stalled-job',
+        payload: { value: 42 },
+        createdAt: oldTimestamp,
+        attempts: 0,
+        maxAttempts: 3
+      }))
+      await storage.registerWorker('worker-1', 60000)
+
+      // Enqueue first, then dequeue to worker's processing queue
+      await storage.enqueue('stalled-job', message, oldTimestamp)
+      await storage.dequeue('worker-1', 1)
+
+      // Now set the state to processing with old timestamp (simulating a stall)
+      await storage.setJobState('stalled-job', `processing:${oldTimestamp}:worker-1`)
+
+      // Track stalled events
+      const stalledJobs: string[] = []
+      reaper.on('stalled', (id) => {
+        stalledJobs.push(id)
+      })
+
+      // Start reaper - should detect the stalled job on startup check
+      await reaper.start()
+
+      // Wait for detection
+      await sleep(150)
+
+      assert.strictEqual(stalledJobs.length, 1)
+      assert.strictEqual(stalledJobs[0], 'stalled-job')
+    })
+
+    it('should check all workers processing queues', async () => {
+      await storage.connect()
+
+      // Set up multiple workers with stalled jobs
+      const oldTimestamp = Date.now() - 200
+
+      for (let i = 1; i <= 2; i++) {
+        const workerId = `worker-${i}`
+        const jobId = `stalled-job-${i}`
+
+        await storage.registerWorker(workerId, 60000)
+
+        const message = Buffer.from(JSON.stringify({
+          id: jobId,
+          payload: { value: i },
+          createdAt: oldTimestamp,
+          attempts: 0,
+          maxAttempts: 3
+        }))
+
+        // Enqueue then dequeue to get into processing queue
+        await storage.enqueue(jobId, message, oldTimestamp)
+        await storage.dequeue(workerId, 1)
+
+        // Set state to processing with old timestamp
+        await storage.setJobState(jobId, `processing:${oldTimestamp}:${workerId}`)
+      }
+
+      const stalledJobs: string[] = []
+      reaper.on('stalled', (id) => {
+        stalledJobs.push(id)
+      })
+
+      await reaper.start()
+
+      // Wait for both jobs to be detected
+      await sleep(150)
+
+      assert.strictEqual(stalledJobs.length, 2)
+      assert.ok(stalledJobs.includes('stalled-job-1'))
+      assert.ok(stalledJobs.includes('stalled-job-2'))
+    })
+  })
+
+  describe('timer management', () => {
+    it('should not leak timers on stop', async () => {
+      // Use separate queue for cleanup control
+      const testQueue = new Queue<{ value: number }, { result: number }>({
+        storage,
+        concurrency: 1,
+        visibilityTimeout: 500
+      })
+
+      let resolveJob: (() => void) | null = null
+      const jobStarted = new Promise<void>(resolve => { resolveJob = resolve })
+      let abortHandler: (() => void) | undefined
+
+      testQueue.execute(async (job: Job<{ value: number }>) => {
+        resolveJob!()
+        // Allow abort for cleanup
+        await new Promise<void>((resolve) => {
+          abortHandler = resolve
+          job.signal.addEventListener('abort', () => resolve())
+        })
+        return { result: 0 }
+      })
+
+      await testQueue.start()
+      await reaper.start()
+
+      // Enqueue a job to start a timer
+      testQueue.enqueue('job-1', { value: 21 })
+
+      // Wait for processing to start
+      await jobStarted
+
+      // Stop reaper - should clear all timers
+      await reaper.stop()
+
+      // Wait past visibility timeout - no errors should occur
+      await sleep(150)
+
+      // Clean up the stuck handler
+      abortHandler?.()
+      await testQueue.stop()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add `Reaper` class that monitors for stalled jobs and requeues them for retry
- Subscribes to storage events to track when jobs start processing
- Starts visibility timeout timers for each processing job
- On timeout, checks if job is still processing and requeues if stalled
- Cancels timers when jobs complete or fail
- Periodic check of all workers' processing queues for recovery
- Emits 'stalled' events when jobs are recovered

This completes M1: Core Working milestone - queue now works with MemoryStorage including stall recovery.

## Test plan
- [x] Reaper lifecycle tests (start/stop)
- [x] Stalled job detection and recovery
- [x] Timer cancellation on job completion/failure
- [x] Periodic check for stalled jobs on startup
- [x] Multiple workers' processing queues checked
- [x] Timer cleanup on stop (no leaks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)