### PR TITLE
fix: Fix CI failures with pnpm 11.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
 jobs:
   ci:
+    strategy:
+      matrix:
+        node-version: [22, 24, 26]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     services:
@@ -48,7 +51,7 @@ jobs:
       - name: Use supported Node.js Version
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ${{ matrix.node-version }}
       - name: Restore cached dependencies
         uses: actions/cache@v3
         with:
@@ -57,7 +60,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 11
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run Tests (Redis)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   ci:
     strategy:
       matrix:
-        node-version: [22, 24, 26]
+        node-version: [22, 24]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     services:

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "typecheck": "tsc -p . --noEmit",
     "format": "prettier -w benchmark src test",
     "test": "c8 -c test/config/c8-local.json node --test-reporter=cleaner-spec-reporter --no-warnings --test --test-timeout=60000 'test/**/*.test.ts'",
-    "test:ci": "node --experimental-test-coverage --test-reporter=cleaner-spec-reporter --no-warnings --test --test-timeout=60000 'test/**/*.test.ts'",
+    "test:ci": "c8 -c test/config/c8-ci.json node --test-reporter=cleaner-spec-reporter --no-warnings --test --test-timeout=60000 'test/**/*.test.ts'",
     "test:docker:up": "docker-compose up -d --wait",
     "test:docker:down": "docker-compose down",
     "ci": "npm run build && npm run lint && npm run test:ci",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "typecheck": "tsc -p . --noEmit",
     "format": "prettier -w benchmark src test",
     "test": "c8 -c test/config/c8-local.json node --test-reporter=cleaner-spec-reporter --no-warnings --test --test-timeout=60000 'test/**/*.test.ts'",
-    "test:ci": "c8 -c test/config/c8-ci.json node --test-reporter=cleaner-spec-reporter --no-warnings --test --test-timeout=60000 'test/**/*.test.ts'",
+    "test:ci": "node --experimental-test-coverage --test-reporter=cleaner-spec-reporter --no-warnings --test --test-timeout=60000 'test/**/*.test.ts'",
     "test:docker:up": "docker-compose up -d --wait",
     "test:docker:down": "docker-compose down",
     "ci": "npm run build && npm run lint && npm run test:ci",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  '@datadog/pprof': true
+  protobufjs: true
+  unrs-resolver: true


### PR DESCRIPTION
This updates CI to exercise Node.js 22 and 24, with pnpm 11, regenerates the pnpm lockfile where needed, and records approved dependency build scripts for pnpm 11.