### PR TITLE
feat: Add SQLiteStorage backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,17 @@ queue.on('error', (error) => {
 
 ### Storage Backends
 
+#### Decision matrix — which backend should I pick?
+
+| Backend | Persistence | Multi-process (same host) | Multi-host | External service | Typical use |
+|---|---|---|---|---|---|
+| `MemoryStorage` | no | no | no | none | tests, single-process scripts |
+| `FileStorage` | yes (filesystem) | yes (atomic renames) | no | none | single-host persistent without SQL |
+| `SQLiteStorage` | yes (SQLite WAL) | **no** (single-process only) | no | none | embedded, persistent, transactional, queryable, single Node process |
+| `RedisStorage` | yes (AOF/RDB) | yes | yes | Redis / Valkey | high-throughput production |
+
+Cross-process job queues require `RedisStorage`. `SQLiteStorage` is **explicitly single-process** — it asserts `process.pid` on every call and throws if you fork after `connect()`.
+
 #### MemoryStorage
 
 In-memory storage for development and testing.
@@ -308,6 +319,52 @@ Features:
 - FIFO ordering via sequence numbers
 - `fs.watch` for real-time notifications
 - Survives process restarts
+
+#### SQLiteStorage
+
+Embedded, persistent, transactional queue for a **single Node process**. Uses the built-in `node:sqlite` module (no native build, no install step beyond this library) with WAL journal mode.
+
+```typescript
+import { SQLiteStorage } from '@platformatic/job-queue'
+
+// In-memory (default — useful for tests or ephemeral queues)
+const memoryDb = new SQLiteStorage()
+
+// File-backed (persistence)
+const persistent = new SQLiteStorage({
+  path: '/var/lib/myapp/jobs.sqlite'
+})
+```
+
+Configuration:
+
+```typescript
+new SQLiteStorage({
+  path: ':memory:',                // default — explicit path required for persistence
+  tablePrefix: 'jq_',
+  cleanupIntervalMs: 30_000,       // or false to disable background cleanup
+  vacuum: { enabled: true, intervalMs: 24 * 60 * 60 * 1000 }, // or false
+  pragmas: { busy_timeout: 100 },  // override defaults; merged with WAL/synchronous/etc.
+  logger                           // pino-compatible
+})
+```
+
+Features:
+- Built-in driver: `node:sqlite` (Node 22+).
+- WAL journal mode with `BEGIN IMMEDIATE` for atomic dequeue
+- In-process write mutex prevents event-loop stalls under contention
+- `node:sqlite` returns `Uint8Array` for BLOBs; `SQLiteStorage` normalizes everything to `Buffer`
+- Leader-elected background cleanup of expired results, errors, workers, locks
+- Periodic `PRAGMA optimize` to keep query plans current
+- Schema version stored in `<prefix>meta`; refuses to start on future-version drift
+
+**Single-process only.** On every call `SQLiteStorage` asserts that `process.pid` matches the pid at `connect()` and throws otherwise. If you fork your worker pool after `connect()`, each child must call `connect()` itself. For genuine multi-process queues use `PgStorage`.
+
+**Filesystem requirements.** WAL mode requires a local filesystem that supports POSIX advisory locking. NFS, SMB, and some container bind-mounts do not — `SQLiteStorage` will log a warning if WAL mode is requested but not active.
+
+**Backups.** A file-backed SQLite database has up to three on-disk artifacts: `<path>`, `<path>-wal`, and `<path>-shm`. Don't `cp` them while the queue is running — use `sqlite3 <path> '.backup <dest>'` or `VACUUM INTO`. The shm file is recreated automatically; you don't need to back it up.
+
+**Schema contract.** `SQLiteStorage` writes a row `(schema_version = '1')` into `<prefix>meta` on first connect. Within the `0.x` line schema changes are non-breaking. A future major version may bump the version and require a migration; `connect()` will refuse to start if it sees an unknown future version.
 
 ### Reaper
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/job-queue",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A reliable job queue with deduplication, request/response support, and pluggable storage",
   "homepage": "https://github.com/platformatic/job-queue",
   "author": "Platformatic Inc. <oss@platformatic.dev> (https://platformatic.dev)",
@@ -14,6 +14,8 @@
     "job-queue",
     "redis",
     "valkey",
+    "postgres",
+    "sqlite",
     "reliable-queue"
   ],
   "private": false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ export { MemoryStorage } from './storage/memory.ts'
 export { RedisStorage } from './storage/redis.ts'
 export { FileStorage } from './storage/file.ts'
 export { PgStorage } from './storage/pg.ts'
+export { SQLiteStorage } from './storage/sqlite.ts'
 
 // Queue
 export { Queue } from './queue.ts'

--- a/src/storage/sqlite.ts
+++ b/src/storage/sqlite.ts
@@ -442,7 +442,7 @@ export class SQLiteStorage implements Storage {
     }
   }
 
-  #acquireMutex (): Promise<() => void> {
+  async #acquireMutex (): Promise<() => void> {
     let resolver!: () => void
     const next = new Promise<void>(resolve => {
       resolver = resolve

--- a/src/storage/sqlite.ts
+++ b/src/storage/sqlite.ts
@@ -438,6 +438,19 @@ export class SQLiteStorage implements Storage {
     return /SQLITE_BUSY|SQLITE_LOCKED|database is locked/i.test(err.message ?? '')
   }
 
+  // SQLite auto-rolls back on hard errors (SQLITE_FULL, SQLITE_IOERR,
+  // SQLITE_NOMEM, SQLITE_INTERRUPT, some SQLITE_BUSY-on-COMMIT cases), so a
+  // follow-up ROLLBACK then errors with "no transaction is active." That's
+  // benign; log at debug so unexpected failures (closed handle, driver bug)
+  // are still greppable.
+  #safeRollback (): void {
+    try {
+      this.#db?.exec('ROLLBACK')
+    } catch (err) {
+      this.#logger.debug({ err }, 'SQLiteStorage: ROLLBACK after failed tx errored (likely auto-rolled back)')
+    }
+  }
+
   #clearDequeueWaiters (): void {
     for (const waiter of this.#dequeueWaiters) {
       clearTimeout(waiter.timeoutId)
@@ -497,11 +510,7 @@ export class SQLiteStorage implements Storage {
         db.exec('COMMIT')
         return null
       } catch (err) {
-        try {
-          db.exec('ROLLBACK')
-        } catch {
-          // ignore
-        }
+        this.#safeRollback()
         throw err
       }
     })
@@ -553,11 +562,7 @@ export class SQLiteStorage implements Storage {
         db.exec('COMMIT')
         return message
       } catch (err) {
-        try {
-          db.exec('ROLLBACK')
-        } catch {
-          // ignore
-        }
+        this.#safeRollback()
         throw err
       }
     })
@@ -572,11 +577,7 @@ export class SQLiteStorage implements Storage {
         db.prepare(`INSERT INTO "${this.#queueTable}" (message) VALUES (?)`).run(message)
         db.exec('COMMIT')
       } catch (err) {
-        try {
-          db.exec('ROLLBACK')
-        } catch {
-          // ignore
-        }
+        this.#safeRollback()
         throw err
       }
     })
@@ -838,11 +839,7 @@ export class SQLiteStorage implements Storage {
         db.prepare(`DELETE FROM "${this.#processingTable}" WHERE worker_id = ? AND message = ?`).run(workerId, message)
         db.exec('COMMIT')
       } catch (err) {
-        try {
-          db.exec('ROLLBACK')
-        } catch {
-          // ignore
-        }
+        this.#safeRollback()
         throw err
       }
     })
@@ -869,11 +866,7 @@ export class SQLiteStorage implements Storage {
         db.prepare(`DELETE FROM "${this.#processingTable}" WHERE worker_id = ? AND message = ?`).run(workerId, message)
         db.exec('COMMIT')
       } catch (err) {
-        try {
-          db.exec('ROLLBACK')
-        } catch {
-          // ignore
-        }
+        this.#safeRollback()
         throw err
       }
     })
@@ -899,11 +892,7 @@ export class SQLiteStorage implements Storage {
         db.prepare(`INSERT INTO "${this.#queueTable}" (message) VALUES (?)`).run(message)
         db.exec('COMMIT')
       } catch (err) {
-        try {
-          db.exec('ROLLBACK')
-        } catch {
-          // ignore
-        }
+        this.#safeRollback()
         throw err
       }
     })
@@ -943,11 +932,7 @@ export class SQLiteStorage implements Storage {
         db.exec('COMMIT')
         return true
       } catch (err) {
-        try {
-          db.exec('ROLLBACK')
-        } catch {
-          // ignore
-        }
+        this.#safeRollback()
         throw err
       }
     })

--- a/src/storage/sqlite.ts
+++ b/src/storage/sqlite.ts
@@ -1,0 +1,1101 @@
+import { EventEmitter } from 'node:events'
+import { randomUUID } from 'node:crypto'
+import { DatabaseSync } from 'node:sqlite'
+import type { Logger } from 'pino'
+import type { Storage } from './types.ts'
+import { abstractLogger } from '../utils/logging.ts'
+import { StorageError } from '../errors.ts'
+
+const SCHEMA_VERSION = 1
+
+const CLEANUP_LOCK_KEY = 'cleanup-leader'
+const CLEANUP_LOCK_TTL_MS = 10_000
+const CLEANUP_ACQUIRE_RETRY_MS = 5_000
+
+// busy_timeout stays at 100ms (Rails 8 default is 5000ms). With node:sqlite's
+// synchronous API, a multi-second busy_timeout would stall the Node event loop
+// under writer contention; ED1 in the design review pairs this short timeout
+// with an in-process write mutex + jittered retry.
+const DEFAULT_BUSY_TIMEOUT_MS = 100
+const DEFAULT_CLEANUP_INTERVAL_MS = 30_000
+const DEFAULT_VACUUM_INTERVAL_MS = 24 * 60 * 60 * 1000
+// Caps the on-disk size of the WAL file after checkpoint. Without it, the WAL
+// can grow unbounded between checkpoints.
+const DEFAULT_JOURNAL_SIZE_LIMIT_BYTES = 64 * 1024 * 1024
+// Memory-mapped I/O for SQLite reads.
+const DEFAULT_MMAP_SIZE_BYTES = 128 * 1024 * 1024
+// Page cache size in number of pages (positive value).
+// With the SQLite 4 KiB default page size this is ~8 MiB.
+const DEFAULT_CACHE_SIZE_PAGES = 2000
+
+const DEFAULT_PRAGMAS: Record<string, string | number> = {
+  journal_mode: 'WAL',
+  synchronous: 'NORMAL',
+  busy_timeout: DEFAULT_BUSY_TIMEOUT_MS,
+  journal_size_limit: DEFAULT_JOURNAL_SIZE_LIMIT_BYTES,
+  mmap_size: DEFAULT_MMAP_SIZE_BYTES,
+  cache_size: DEFAULT_CACHE_SIZE_PAGES,
+  temp_store: 'MEMORY'
+}
+
+const WRITE_RETRY_BASE_MS = 5
+const WRITE_RETRY_MAX_MS = 50
+const WRITE_RETRY_ATTEMPTS = 5
+
+interface DequeueWaiter {
+  workerId: string
+  resolve: (value: Buffer | null) => void
+  timeoutId: ReturnType<typeof setTimeout>
+}
+
+interface VacuumOption {
+  enabled: boolean
+  intervalMs: number
+}
+
+interface SQLiteStorageConfig {
+  /**
+   * Database path. Use ':memory:' for an in-memory database (default).
+   * For persistence pass an explicit filesystem path. No silent cwd writes.
+   */
+  path?: string
+
+  /**
+   * Table name prefix.
+   * Default: 'jq_'.
+   */
+  tablePrefix?: string
+
+  /**
+   * Background cleanup interval in milliseconds. Pass false to disable
+   * (useful if you run cleanup externally via SQL).
+   * Default: 30000.
+   */
+  cleanupIntervalMs?: number | false
+
+  /**
+   * Periodic VACUUM / pragma optimize cadence.
+   * Pass false to disable.
+   * Default: { enabled: true, intervalMs: 24 * 60 * 60 * 1000 }.
+   */
+  vacuum?: VacuumOption | false
+
+  /**
+   * PRAGMA overrides merged over the defaults.
+   * Useful for tuning busy_timeout, cache_size, mmap_size, etc.
+   */
+  pragmas?: Record<string, string | number>
+
+  /**
+   * Pino logger for structured operational log lines.
+   */
+  logger?: Logger
+}
+
+function toBuffer (value: unknown): Buffer {
+  if (Buffer.isBuffer(value)) return value
+  if (value instanceof Uint8Array) {
+    return Buffer.from(value.buffer, value.byteOffset, value.byteLength)
+  }
+  if (typeof value === 'string') return Buffer.from(value)
+  throw new StorageError(`SQLiteStorage: expected Buffer/Uint8Array, got ${typeof value}`)
+}
+
+function sleep (ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+/**
+ * SQLite storage implementation.
+ *
+ * Single-process only. Uses node:sqlite (built in since Node 22.5) with WAL mode.
+ * Cross-process use is intentionally unsupported: every call asserts that the
+ * caller's process.pid matches the pid at connect(), and throws StorageError
+ * otherwise. For multi-process queues, use PgStorage.
+ *
+ * Notification semantics: subscribeToJob handlers must run in the same process
+ * as the publisher. SQLite has no LISTEN/NOTIFY equivalent; we use an in-process
+ * EventEmitter and document the contract explicitly.
+ *
+ * Atomic dequeue uses BEGIN IMMEDIATE; in-process writers are serialized through
+ * an async mutex to avoid event-loop stalls when contention would otherwise let
+ * busy_timeout block the synchronous driver.
+ */
+export class SQLiteStorage implements Storage {
+  #path: string
+  #tablePrefix: string
+  #cleanupIntervalMs: number | false
+  #vacuum: VacuumOption | false
+  #pragmas: Record<string, string | number>
+  #logger: Logger
+
+  #db: DatabaseSync | null = null
+  #connectedPid: number | null = null
+
+  #eventEmitter = new EventEmitter({ captureRejections: true })
+  #notifyEmitter = new EventEmitter({ captureRejections: true })
+  #dequeueWaiters: DequeueWaiter[] = []
+
+  #cleanupInterval: ReturnType<typeof setInterval> | null = null
+  #leadershipTimer: ReturnType<typeof setInterval> | null = null
+  #vacuumInterval: ReturnType<typeof setInterval> | null = null
+  #writeMutex: Promise<void> = Promise.resolve()
+
+  #instanceId = randomUUID()
+  #isCleanupLeader = false
+
+  // Namespace support — shares the database handle with a root instance.
+  #parentStorage: SQLiteStorage | null = null
+  #refCount = 0
+
+  // Table names (computed from prefix).
+  #jobsTable: string
+  #queueTable: string
+  #processingTable: string
+  #resultsTable: string
+  #errorsTable: string
+  #workersTable: string
+  #locksTable: string
+  #metaTable: string
+
+  constructor (config: SQLiteStorageConfig = {}) {
+    this.#path = config.path ?? ':memory:'
+    this.#tablePrefix = config.tablePrefix ?? 'jq_'
+
+    this.#cleanupIntervalMs = config.cleanupIntervalMs ?? DEFAULT_CLEANUP_INTERVAL_MS
+    this.#vacuum =
+      config.vacuum === undefined ? { enabled: true, intervalMs: DEFAULT_VACUUM_INTERVAL_MS } : config.vacuum
+
+    this.#pragmas = { ...DEFAULT_PRAGMAS, ...(config.pragmas ?? {}) }
+    this.#logger = (config.logger ?? abstractLogger).child({
+      component: 'sqlite-storage',
+      tablePrefix: this.#tablePrefix
+    })
+
+    this.#jobsTable = `${this.#tablePrefix}jobs`
+    this.#queueTable = `${this.#tablePrefix}queue`
+    this.#processingTable = `${this.#tablePrefix}processing`
+    this.#resultsTable = `${this.#tablePrefix}results`
+    this.#errorsTable = `${this.#tablePrefix}errors`
+    this.#workersTable = `${this.#tablePrefix}workers`
+    this.#locksTable = `${this.#tablePrefix}locks`
+    this.#metaTable = `${this.#tablePrefix}meta`
+
+    this.#eventEmitter.setMaxListeners(0)
+    this.#notifyEmitter.setMaxListeners(0)
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
+  // LIFECYCLE
+  // ═══════════════════════════════════════════════════════════════════
+
+  async connect (): Promise<void> {
+    if (this.#parentStorage) {
+      if (this.#db) return // already connected
+      this.#parentStorage.#refCount++
+      await this.#parentStorage.connect()
+      this.#db = this.#parentStorage.#db
+      this.#connectedPid = this.#parentStorage.#connectedPid
+      this.#createSchema()
+      return
+    }
+
+    if (this.#db) return // idempotent
+
+    try {
+      this.#db = new DatabaseSync(this.#path)
+    } catch (err) {
+      const error = err as NodeJS.ErrnoException
+      throw new StorageError(`SQLiteStorage: failed to open '${this.#path}': ${error.message}`, error)
+    }
+    this.#connectedPid = process.pid
+
+    this.#applyPragmas()
+    this.#assertWalActive()
+    this.#createSchema()
+    this.#checkSchemaVersion()
+    this.#startCleanupLeaderLoop()
+    this.#startVacuumLoop()
+  }
+
+  async disconnect (): Promise<void> {
+    if (this.#parentStorage) {
+      this.#clearDequeueWaiters()
+      this.#eventEmitter.removeAllListeners()
+      this.#notifyEmitter.removeAllListeners()
+      this.#db = null
+      this.#connectedPid = null
+      this.#parentStorage.#refCount--
+      return
+    }
+
+    if (this.#refCount > 0) return // children still connected
+
+    if (this.#leadershipTimer) {
+      clearInterval(this.#leadershipTimer)
+      this.#leadershipTimer = null
+    }
+    if (this.#cleanupInterval) {
+      clearInterval(this.#cleanupInterval)
+      this.#cleanupInterval = null
+    }
+    if (this.#vacuumInterval) {
+      clearInterval(this.#vacuumInterval)
+      this.#vacuumInterval = null
+    }
+
+    if (this.#isCleanupLeader) {
+      try {
+        await this.releaseLeaderLock(CLEANUP_LOCK_KEY, this.#instanceId)
+      } catch {
+        // best-effort
+      }
+      this.#isCleanupLeader = false
+    }
+
+    this.#clearDequeueWaiters()
+    this.#eventEmitter.removeAllListeners()
+    this.#notifyEmitter.removeAllListeners()
+
+    if (this.#db) {
+      try {
+        this.#db.close()
+      } catch {
+        // best-effort
+      }
+      this.#db = null
+    }
+    this.#connectedPid = null
+  }
+
+  #applyPragmas (): void {
+    const db = this.#db!
+    for (const [key, value] of Object.entries(this.#pragmas)) {
+      const formattedValue = typeof value === 'string' ? value : String(value)
+      db.exec(`PRAGMA ${key} = ${formattedValue}`)
+    }
+  }
+
+  #assertWalActive (): void {
+    if (this.#path === ':memory:') return // WAL not applicable for :memory:
+    const requestedJournalMode = String(this.#pragmas.journal_mode ?? '').toLowerCase()
+    if (requestedJournalMode !== 'wal') return
+    const row = this.#db!.prepare('PRAGMA journal_mode').get() as { journal_mode?: string } | undefined
+    const actual = row?.journal_mode?.toLowerCase()
+    if (actual !== 'wal') {
+      this.#logger.warn(
+        { requested: 'wal', actual },
+        'SQLiteStorage: WAL mode requested but not active. This usually means the path is on a filesystem that does not support WAL (NFS, some bind-mounts). Cleanup and dequeue throughput will be reduced.'
+      )
+    }
+  }
+
+  #createSchema (): void {
+    const db = this.#db!
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS "${this.#jobsTable}" (
+        id TEXT PRIMARY KEY,
+        state TEXT NOT NULL,
+        expires_at INTEGER
+      );
+      CREATE TABLE IF NOT EXISTS "${this.#queueTable}" (
+        seq INTEGER PRIMARY KEY AUTOINCREMENT,
+        message BLOB NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS "${this.#processingTable}" (
+        seq INTEGER PRIMARY KEY AUTOINCREMENT,
+        worker_id TEXT NOT NULL,
+        message BLOB NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS "${this.#processingTable}_worker_idx"
+        ON "${this.#processingTable}" (worker_id);
+      CREATE TABLE IF NOT EXISTS "${this.#resultsTable}" (
+        id TEXT PRIMARY KEY,
+        data BLOB NOT NULL,
+        expires_at INTEGER NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS "${this.#resultsTable}_expires_idx"
+        ON "${this.#resultsTable}" (expires_at);
+      CREATE TABLE IF NOT EXISTS "${this.#errorsTable}" (
+        id TEXT PRIMARY KEY,
+        data BLOB NOT NULL,
+        expires_at INTEGER NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS "${this.#errorsTable}_expires_idx"
+        ON "${this.#errorsTable}" (expires_at);
+      CREATE TABLE IF NOT EXISTS "${this.#workersTable}" (
+        worker_id TEXT PRIMARY KEY,
+        expires_at INTEGER NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS "${this.#workersTable}_expires_idx"
+        ON "${this.#workersTable}" (expires_at);
+      CREATE TABLE IF NOT EXISTS "${this.#locksTable}" (
+        lock_key TEXT PRIMARY KEY,
+        owner_id TEXT NOT NULL,
+        expires_at INTEGER NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS "${this.#metaTable}" (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      );
+    `)
+  }
+
+  #checkSchemaVersion (): void {
+    const db = this.#db!
+    const row = db.prepare(`SELECT value FROM "${this.#metaTable}" WHERE key = 'schema_version'`).get() as
+      | { value?: string }
+      | undefined
+
+    if (!row) {
+      db.prepare(`INSERT OR IGNORE INTO "${this.#metaTable}" (key, value) VALUES ('schema_version', ?)`).run(
+        String(SCHEMA_VERSION)
+      )
+      return
+    }
+
+    const found = parseInt(row.value ?? '0', 10)
+    if (Number.isNaN(found) || found > SCHEMA_VERSION) {
+      throw new StorageError(
+        `SQLiteStorage: database schema version ${row.value ?? '(invalid)'} is not supported ` +
+          `by this library (supports schema v${SCHEMA_VERSION}). Downgrade is not supported.`
+      )
+    }
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
+  // INTERNAL HELPERS
+  // ═══════════════════════════════════════════════════════════════════
+
+  #assertConnected (): DatabaseSync {
+    if (!this.#db) {
+      throw new StorageError('SQLiteStorage: not connected. Call connect() first.')
+    }
+    if (this.#connectedPid !== null && process.pid !== this.#connectedPid) {
+      throw new StorageError(
+        'SQLiteStorage: detected use from a forked process ' +
+          `(connected pid=${this.#connectedPid}, current pid=${process.pid}). ` +
+          'SQLiteStorage is single-process only; forked children must call connect() after fork(). ' +
+          'For multi-process queues, use PgStorage.'
+      )
+    }
+    return this.#db
+  }
+
+  /**
+   * Serializes write operations through an async mutex and retries with jitter
+   * on SQLITE_BUSY. Reads do NOT take the mutex; SQLite handles concurrent reads
+   * via WAL.
+   */
+  async #runWrite<T> (fn: () => T): Promise<T> {
+    const release = await this.#acquireMutex()
+    try {
+      let lastError: unknown
+      for (let attempt = 0; attempt < WRITE_RETRY_ATTEMPTS; attempt++) {
+        try {
+          return fn()
+        } catch (err) {
+          lastError = err
+          if (!this.#isBusyError(err)) {
+            throw err
+          }
+          const backoff = Math.min(WRITE_RETRY_BASE_MS * 2 ** attempt, WRITE_RETRY_MAX_MS)
+          const jitter = Math.floor(Math.random() * backoff)
+          this.#logger.warn(
+            { attempt: attempt + 1, backoffMs: backoff + jitter, err: (err as Error).message },
+            'SQLiteStorage: writer locked, retrying'
+          )
+          await sleep(backoff + jitter)
+        }
+      }
+      throw new StorageError(
+        `SQLiteStorage: database is locked after ${WRITE_RETRY_ATTEMPTS} retries ` +
+          '(~' +
+          WRITE_RETRY_ATTEMPTS * WRITE_RETRY_MAX_MS +
+          'ms). Another writer is holding the lock. ' +
+          'Either reduce contention, increase busy_timeout via pragmas, or switch to PgStorage.',
+        lastError instanceof Error ? lastError : undefined
+      )
+    } finally {
+      release()
+    }
+  }
+
+  #acquireMutex (): Promise<() => void> {
+    let resolver!: () => void
+    const next = new Promise<void>(resolve => {
+      resolver = resolve
+    })
+    const previous = this.#writeMutex
+    this.#writeMutex = previous.then(() => next)
+    return previous.then(() => resolver)
+  }
+
+  #isBusyError (err: unknown): boolean {
+    if (!(err instanceof Error)) return false
+    const code = (err as NodeJS.ErrnoException).code
+    if (code === 'SQLITE_BUSY' || code === 'SQLITE_LOCKED') return true
+    return /SQLITE_BUSY|SQLITE_LOCKED|database is locked/i.test(err.message ?? '')
+  }
+
+  #clearDequeueWaiters (): void {
+    for (const waiter of this.#dequeueWaiters) {
+      clearTimeout(waiter.timeoutId)
+      waiter.resolve(null)
+    }
+    this.#dequeueWaiters = []
+  }
+
+  #notifyDequeueWaiters (): void {
+    // Pop waiters and try to give each a message. Each attempt is its own write tx.
+    const waiters = this.#dequeueWaiters.splice(0)
+    for (const waiter of waiters) {
+      this.#tryDequeue(waiter.workerId)
+        .then(msg => {
+          if (msg) {
+            clearTimeout(waiter.timeoutId)
+            waiter.resolve(msg)
+          } else {
+            this.#dequeueWaiters.push(waiter)
+          }
+        })
+        .catch(err => {
+          this.#logger.error({ err }, 'SQLiteStorage: dequeue waiter failed; will retry')
+          this.#dequeueWaiters.push(waiter)
+        })
+    }
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
+  // QUEUE OPERATIONS
+  // ═══════════════════════════════════════════════════════════════════
+
+  async enqueue (id: string, message: Buffer, timestamp: number): Promise<string | null> {
+    const db = this.#assertConnected()
+    const state = `queued:${timestamp}`
+    const now = Date.now()
+
+    const existing = await this.#runWrite(() => {
+      db.exec('BEGIN IMMEDIATE')
+      try {
+        const row = db.prepare(`SELECT state, expires_at FROM "${this.#jobsTable}" WHERE id = ?`).get(id) as
+          | { state?: string; expires_at?: number | null }
+          | undefined
+
+        if (row) {
+          const expiresAt = row.expires_at ?? null
+          if (expiresAt && now >= expiresAt) {
+            db.prepare(`DELETE FROM "${this.#jobsTable}" WHERE id = ?`).run(id)
+          } else {
+            db.exec('COMMIT')
+            return row.state ?? null
+          }
+        }
+
+        db.prepare(`INSERT INTO "${this.#jobsTable}" (id, state) VALUES (?, ?)`).run(id, state)
+        db.prepare(`INSERT INTO "${this.#queueTable}" (message) VALUES (?)`).run(message)
+        db.exec('COMMIT')
+        return null
+      } catch (err) {
+        try {
+          db.exec('ROLLBACK')
+        } catch {
+          // ignore
+        }
+        throw err
+      }
+    })
+
+    if (existing === null) {
+      this.#eventEmitter.emit('event', id, 'queued')
+      this.#notifyDequeueWaiters()
+    }
+
+    return existing
+  }
+
+  async dequeue (workerId: string, timeout: number): Promise<Buffer | null> {
+    this.#assertConnected()
+    const immediate = await this.#tryDequeue(workerId)
+    if (immediate) return immediate
+
+    return new Promise<Buffer | null>(resolve => {
+      const timeoutId = setTimeout(() => {
+        const index = this.#dequeueWaiters.findIndex(w => w.resolve === resolve)
+        if (index !== -1) this.#dequeueWaiters.splice(index, 1)
+        resolve(null)
+      }, timeout * 1000)
+
+      this.#dequeueWaiters.push({ workerId, resolve, timeoutId })
+    })
+  }
+
+  async #tryDequeue (workerId: string): Promise<Buffer | null> {
+    const db = this.#assertConnected()
+    return this.#runWrite(() => {
+      db.exec('BEGIN IMMEDIATE')
+      try {
+        const row = db
+          .prepare(
+            `DELETE FROM "${this.#queueTable}"
+             WHERE seq = (SELECT seq FROM "${this.#queueTable}" ORDER BY seq LIMIT 1)
+             RETURNING message`
+          )
+          .get() as { message?: unknown } | undefined
+
+        if (!row || row.message === undefined) {
+          db.exec('COMMIT')
+          return null
+        }
+
+        const message = toBuffer(row.message)
+        db.prepare(`INSERT INTO "${this.#processingTable}" (worker_id, message) VALUES (?, ?)`).run(workerId, message)
+        db.exec('COMMIT')
+        return message
+      } catch (err) {
+        try {
+          db.exec('ROLLBACK')
+        } catch {
+          // ignore
+        }
+        throw err
+      }
+    })
+  }
+
+  async requeue (id: string, message: Buffer, workerId: string): Promise<void> {
+    const db = this.#assertConnected()
+    await this.#runWrite(() => {
+      db.exec('BEGIN IMMEDIATE')
+      try {
+        db.prepare(`DELETE FROM "${this.#processingTable}" WHERE worker_id = ? AND message = ?`).run(workerId, message)
+        db.prepare(`INSERT INTO "${this.#queueTable}" (message) VALUES (?)`).run(message)
+        db.exec('COMMIT')
+      } catch (err) {
+        try {
+          db.exec('ROLLBACK')
+        } catch {
+          // ignore
+        }
+        throw err
+      }
+    })
+    this.#notifyDequeueWaiters()
+  }
+
+  async ack (id: string, message: Buffer, workerId: string): Promise<void> {
+    const db = this.#assertConnected()
+    await this.#runWrite(() => {
+      db.prepare(`DELETE FROM "${this.#processingTable}" WHERE worker_id = ? AND message = ?`).run(workerId, message)
+    })
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
+  // JOB STATE
+  // ═══════════════════════════════════════════════════════════════════
+
+  async getJobState (id: string): Promise<string | null> {
+    const db = this.#assertConnected()
+    const row = db.prepare(`SELECT state, expires_at FROM "${this.#jobsTable}" WHERE id = ?`).get(id) as
+      | { state?: string; expires_at?: number | null }
+      | undefined
+
+    if (!row) return null
+    const expiresAt = row.expires_at ?? null
+    if (expiresAt && Date.now() >= expiresAt) {
+      await this.#runWrite(() => {
+        db.prepare(`DELETE FROM "${this.#jobsTable}" WHERE id = ?`).run(id)
+      })
+      return null
+    }
+    return row.state ?? null
+  }
+
+  async setJobState (id: string, state: string): Promise<void> {
+    const db = this.#assertConnected()
+    await this.#runWrite(() => {
+      db.prepare(`UPDATE "${this.#jobsTable}" SET state = ? WHERE id = ?`).run(state, id)
+    })
+  }
+
+  async deleteJob (id: string): Promise<boolean> {
+    const db = this.#assertConnected()
+    const changes = await this.#runWrite(() => {
+      const result = db.prepare(`DELETE FROM "${this.#jobsTable}" WHERE id = ?`).run(id)
+      return result.changes
+    })
+    if (changes > 0) {
+      this.#eventEmitter.emit('event', id, 'cancelled')
+      return true
+    }
+    return false
+  }
+
+  async getJobStates (ids: string[]): Promise<Map<string, string | null>> {
+    const result = new Map<string, string | null>()
+    if (ids.length === 0) return result
+
+    const db = this.#assertConnected()
+    const placeholders = ids.map(() => '?').join(',')
+    const rows = db
+      .prepare(`SELECT id, state, expires_at FROM "${this.#jobsTable}" WHERE id IN (${placeholders})`)
+      .all(...ids) as Array<{ id: string; state: string; expires_at: number | null }>
+
+    const now = Date.now()
+    const found = new Set<string>()
+    const expiredIds: string[] = []
+
+    for (const row of rows) {
+      found.add(row.id)
+      if (row.expires_at && now >= row.expires_at) {
+        expiredIds.push(row.id)
+        result.set(row.id, null)
+      } else {
+        result.set(row.id, row.state)
+      }
+    }
+
+    if (expiredIds.length > 0) {
+      const expiredPlaceholders = expiredIds.map(() => '?').join(',')
+      await this.#runWrite(() => {
+        db.prepare(`DELETE FROM "${this.#jobsTable}" WHERE id IN (${expiredPlaceholders})`).run(...expiredIds)
+      })
+    }
+
+    for (const id of ids) {
+      if (!found.has(id)) result.set(id, null)
+    }
+
+    return result
+  }
+
+  async setJobExpiry (id: string, ttlMs: number): Promise<void> {
+    const db = this.#assertConnected()
+    const expiresAt = Date.now() + ttlMs
+    await this.#runWrite(() => {
+      db.prepare(`UPDATE "${this.#jobsTable}" SET expires_at = ? WHERE id = ?`).run(expiresAt, id)
+    })
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
+  // RESULTS
+  // ═══════════════════════════════════════════════════════════════════
+
+  async setResult (id: string, result: Buffer, ttlMs: number): Promise<void> {
+    const db = this.#assertConnected()
+    const expiresAt = Date.now() + ttlMs
+    await this.#runWrite(() => {
+      db.prepare(
+        `INSERT INTO "${this.#resultsTable}" (id, data, expires_at)
+         VALUES (?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET data = excluded.data, expires_at = excluded.expires_at`
+      ).run(id, result, expiresAt)
+    })
+  }
+
+  async getResult (id: string): Promise<Buffer | null> {
+    const db = this.#assertConnected()
+    const row = db.prepare(`SELECT data, expires_at FROM "${this.#resultsTable}" WHERE id = ?`).get(id) as
+      | { data?: unknown; expires_at?: number }
+      | undefined
+    if (!row) return null
+    if (row.expires_at !== undefined && Date.now() > row.expires_at) {
+      await this.#runWrite(() => {
+        db.prepare(`DELETE FROM "${this.#resultsTable}" WHERE id = ?`).run(id)
+      })
+      return null
+    }
+    return toBuffer(row.data)
+  }
+
+  async setError (id: string, error: Buffer, ttlMs: number): Promise<void> {
+    const db = this.#assertConnected()
+    const expiresAt = Date.now() + ttlMs
+    await this.#runWrite(() => {
+      db.prepare(
+        `INSERT INTO "${this.#errorsTable}" (id, data, expires_at)
+         VALUES (?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET data = excluded.data, expires_at = excluded.expires_at`
+      ).run(id, error, expiresAt)
+    })
+  }
+
+  async getError (id: string): Promise<Buffer | null> {
+    const db = this.#assertConnected()
+    const row = db.prepare(`SELECT data, expires_at FROM "${this.#errorsTable}" WHERE id = ?`).get(id) as
+      | { data?: unknown; expires_at?: number }
+      | undefined
+    if (!row) return null
+    if (row.expires_at !== undefined && Date.now() > row.expires_at) {
+      await this.#runWrite(() => {
+        db.prepare(`DELETE FROM "${this.#errorsTable}" WHERE id = ?`).run(id)
+      })
+      return null
+    }
+    return toBuffer(row.data)
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
+  // WORKERS
+  // ═══════════════════════════════════════════════════════════════════
+
+  async registerWorker (workerId: string, ttlMs: number): Promise<void> {
+    const db = this.#assertConnected()
+    const expiresAt = Date.now() + ttlMs
+    await this.#runWrite(() => {
+      db.prepare(
+        `INSERT INTO "${this.#workersTable}" (worker_id, expires_at)
+         VALUES (?, ?)
+         ON CONFLICT(worker_id) DO UPDATE SET expires_at = excluded.expires_at`
+      ).run(workerId, expiresAt)
+    })
+  }
+
+  async refreshWorker (workerId: string, ttlMs: number): Promise<void> {
+    return this.registerWorker(workerId, ttlMs)
+  }
+
+  async unregisterWorker (workerId: string): Promise<void> {
+    if (!this.#db) return
+    const db = this.#db
+    await this.#runWrite(() => {
+      db.prepare(`DELETE FROM "${this.#workersTable}" WHERE worker_id = ?`).run(workerId)
+      db.prepare(`DELETE FROM "${this.#processingTable}" WHERE worker_id = ?`).run(workerId)
+    })
+  }
+
+  async getWorkers (): Promise<string[]> {
+    const db = this.#assertConnected()
+    const rows = db
+      .prepare(`SELECT worker_id FROM "${this.#workersTable}" WHERE expires_at > ?`)
+      .all(Date.now()) as Array<{ worker_id: string }>
+    return rows.map(r => r.worker_id)
+  }
+
+  async getProcessingJobs (workerId: string): Promise<Buffer[]> {
+    const db = this.#assertConnected()
+    const rows = db
+      .prepare(`SELECT message FROM "${this.#processingTable}" WHERE worker_id = ?`)
+      .all(workerId) as Array<{ message: unknown }>
+    return rows.map(r => toBuffer(r.message))
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
+  // NOTIFICATIONS (in-process only)
+  // ═══════════════════════════════════════════════════════════════════
+
+  async subscribeToJob (
+    id: string,
+    handler: (status: 'completed' | 'failed' | 'failing') => void
+  ): Promise<() => Promise<void>> {
+    const eventName = `notify:${id}`
+    this.#notifyEmitter.on(eventName, handler)
+    return async () => {
+      this.#notifyEmitter.off(eventName, handler)
+    }
+  }
+
+  async notifyJobComplete (id: string, status: 'completed' | 'failed' | 'failing'): Promise<void> {
+    this.#assertConnected()
+    this.#notifyEmitter.emit(`notify:${id}`, status)
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
+  // EVENTS
+  // ═══════════════════════════════════════════════════════════════════
+
+  async subscribeToEvents (handler: (id: string, event: string) => void): Promise<() => Promise<void>> {
+    this.#eventEmitter.on('event', handler)
+    return async () => {
+      this.#eventEmitter.off('event', handler)
+    }
+  }
+
+  async publishEvent (id: string, event: string): Promise<void> {
+    this.#assertConnected()
+    this.#eventEmitter.emit('event', id, event)
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
+  // ATOMIC OPERATIONS
+  // ═══════════════════════════════════════════════════════════════════
+
+  async completeJob (id: string, message: Buffer, workerId: string, result: Buffer, resultTTL: number): Promise<void> {
+    const db = this.#assertConnected()
+    const timestamp = Date.now()
+    const state = `completed:${timestamp}`
+    const expiresAt = timestamp + resultTTL
+
+    await this.#runWrite(() => {
+      db.exec('BEGIN IMMEDIATE')
+      try {
+        db.prepare(`UPDATE "${this.#jobsTable}" SET state = ?, expires_at = ? WHERE id = ?`).run(state, expiresAt, id)
+        db.prepare(
+          `INSERT INTO "${this.#resultsTable}" (id, data, expires_at)
+           VALUES (?, ?, ?)
+           ON CONFLICT(id) DO UPDATE SET data = excluded.data, expires_at = excluded.expires_at`
+        ).run(id, result, expiresAt)
+        db.prepare(`DELETE FROM "${this.#processingTable}" WHERE worker_id = ? AND message = ?`).run(workerId, message)
+        db.exec('COMMIT')
+      } catch (err) {
+        try {
+          db.exec('ROLLBACK')
+        } catch {
+          // ignore
+        }
+        throw err
+      }
+    })
+
+    this.#notifyEmitter.emit(`notify:${id}`, 'completed')
+    this.#eventEmitter.emit('event', id, 'completed')
+  }
+
+  async failJob (id: string, message: Buffer, workerId: string, error: Buffer, errorTTL: number): Promise<void> {
+    const db = this.#assertConnected()
+    const timestamp = Date.now()
+    const state = `failed:${timestamp}`
+    const expiresAt = timestamp + errorTTL
+
+    await this.#runWrite(() => {
+      db.exec('BEGIN IMMEDIATE')
+      try {
+        db.prepare(`UPDATE "${this.#jobsTable}" SET state = ?, expires_at = ? WHERE id = ?`).run(state, expiresAt, id)
+        db.prepare(
+          `INSERT INTO "${this.#errorsTable}" (id, data, expires_at)
+           VALUES (?, ?, ?)
+           ON CONFLICT(id) DO UPDATE SET data = excluded.data, expires_at = excluded.expires_at`
+        ).run(id, error, expiresAt)
+        db.prepare(`DELETE FROM "${this.#processingTable}" WHERE worker_id = ? AND message = ?`).run(workerId, message)
+        db.exec('COMMIT')
+      } catch (err) {
+        try {
+          db.exec('ROLLBACK')
+        } catch {
+          // ignore
+        }
+        throw err
+      }
+    })
+
+    this.#notifyEmitter.emit(`notify:${id}`, 'failed')
+    this.#eventEmitter.emit('event', id, 'failed')
+  }
+
+  async retryJob (id: string, message: Buffer, workerId: string, attempts: number): Promise<void> {
+    const db = this.#assertConnected()
+    const timestamp = Date.now()
+    const state = `failing:${timestamp}:${attempts}`
+
+    // Find the old processing row by worker_id. We don't parse JSON; we match all
+    // processing rows for the worker and remove them. Single-process semantics
+    // mean only one row per (worker_id, job-in-flight) is expected.
+    await this.#runWrite(() => {
+      db.exec('BEGIN IMMEDIATE')
+      try {
+        db.prepare(`UPDATE "${this.#jobsTable}" SET state = ? WHERE id = ?`).run(state, id)
+        // Delete the processing row that matches by worker_id (single-process: at most one in flight).
+        db.prepare(`DELETE FROM "${this.#processingTable}" WHERE worker_id = ?`).run(workerId)
+        db.prepare(`INSERT INTO "${this.#queueTable}" (message) VALUES (?)`).run(message)
+        db.exec('COMMIT')
+      } catch (err) {
+        try {
+          db.exec('ROLLBACK')
+        } catch {
+          // ignore
+        }
+        throw err
+      }
+    })
+
+    this.#notifyEmitter.emit(`notify:${id}`, 'failing')
+    this.#eventEmitter.emit('event', id, 'failing')
+    this.#notifyDequeueWaiters()
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
+  // LEADER ELECTION
+  // ═══════════════════════════════════════════════════════════════════
+
+  async acquireLeaderLock (lockKey: string, ownerId: string, ttlMs: number): Promise<boolean> {
+    const db = this.#assertConnected()
+    const expiresAt = Date.now() + ttlMs
+
+    return this.#runWrite(() => {
+      db.exec('BEGIN IMMEDIATE')
+      try {
+        const row = db
+          .prepare(`SELECT owner_id, expires_at FROM "${this.#locksTable}" WHERE lock_key = ?`)
+          .get(lockKey) as { owner_id?: string; expires_at?: number } | undefined
+
+        const now = Date.now()
+        if (row && row.expires_at !== undefined && now < row.expires_at) {
+          db.exec('COMMIT')
+          return false
+        }
+
+        db.prepare(
+          `INSERT INTO "${this.#locksTable}" (lock_key, owner_id, expires_at)
+           VALUES (?, ?, ?)
+           ON CONFLICT(lock_key) DO UPDATE
+             SET owner_id = excluded.owner_id, expires_at = excluded.expires_at`
+        ).run(lockKey, ownerId, expiresAt)
+        db.exec('COMMIT')
+        return true
+      } catch (err) {
+        try {
+          db.exec('ROLLBACK')
+        } catch {
+          // ignore
+        }
+        throw err
+      }
+    })
+  }
+
+  async renewLeaderLock (lockKey: string, ownerId: string, ttlMs: number): Promise<boolean> {
+    const db = this.#assertConnected()
+    const expiresAt = Date.now() + ttlMs
+    return this.#runWrite(() => {
+      const result = db
+        .prepare(`UPDATE "${this.#locksTable}" SET expires_at = ? WHERE lock_key = ? AND owner_id = ?`)
+        .run(expiresAt, lockKey, ownerId)
+      return result.changes > 0
+    })
+  }
+
+  async releaseLeaderLock (lockKey: string, ownerId: string): Promise<boolean> {
+    if (!this.#db) return false
+    const db = this.#db
+    return this.#runWrite(() => {
+      const result = db
+        .prepare(`DELETE FROM "${this.#locksTable}" WHERE lock_key = ? AND owner_id = ?`)
+        .run(lockKey, ownerId)
+      return result.changes > 0
+    })
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
+  // CLEANUP LEADER + VACUUM
+  // ═══════════════════════════════════════════════════════════════════
+
+  #startCleanupLeaderLoop (): void {
+    if (this.#cleanupIntervalMs === false) return
+    if (this.#parentStorage) return // children don't run cleanup
+
+    const tick = (): void => {
+      this.#leadershipTick().catch(err => {
+        this.#logger.error({ err }, 'SQLiteStorage: leadership tick failed')
+      })
+    }
+
+    this.#leadershipTimer = setInterval(tick, CLEANUP_ACQUIRE_RETRY_MS)
+    // Try once immediately so the first cleanup runs soon.
+    setImmediate(tick)
+  }
+
+  async #leadershipTick (): Promise<void> {
+    if (!this.#db) return
+
+    if (this.#isCleanupLeader) {
+      const renewed = await this.renewLeaderLock(CLEANUP_LOCK_KEY, this.#instanceId, CLEANUP_LOCK_TTL_MS)
+      if (!renewed) {
+        this.#isCleanupLeader = false
+        this.#stopCleanupInterval()
+        this.#logger.info('SQLiteStorage: lost cleanup leadership')
+      }
+    } else {
+      const acquired = await this.acquireLeaderLock(CLEANUP_LOCK_KEY, this.#instanceId, CLEANUP_LOCK_TTL_MS)
+      if (acquired) {
+        this.#isCleanupLeader = true
+        this.#startCleanupInterval()
+        this.#logger.info('SQLiteStorage: acquired cleanup leadership')
+      }
+    }
+  }
+
+  #startCleanupInterval (): void {
+    if (this.#cleanupInterval || this.#cleanupIntervalMs === false) return
+    const intervalMs = this.#cleanupIntervalMs as number
+    this.#cleanupInterval = setInterval(() => {
+      this.#cleanupExpired().catch(err => {
+        this.#logger.error({ err }, 'SQLiteStorage: cleanup sweep failed')
+      })
+    }, intervalMs)
+  }
+
+  #stopCleanupInterval (): void {
+    if (this.#cleanupInterval) {
+      clearInterval(this.#cleanupInterval)
+      this.#cleanupInterval = null
+    }
+  }
+
+  async #cleanupExpired (): Promise<void> {
+    const db = this.#assertConnected()
+    const now = Date.now()
+    const start = now
+
+    await this.#runWrite(() => {
+      db.prepare(`DELETE FROM "${this.#resultsTable}" WHERE expires_at < ?`).run(now)
+      db.prepare(`DELETE FROM "${this.#errorsTable}" WHERE expires_at < ?`).run(now)
+      db.prepare(`DELETE FROM "${this.#workersTable}" WHERE expires_at < ?`).run(now)
+      db.prepare(`DELETE FROM "${this.#jobsTable}" WHERE expires_at IS NOT NULL AND expires_at < ?`).run(now)
+      db.prepare(`DELETE FROM "${this.#locksTable}" WHERE expires_at < ?`).run(now)
+    })
+
+    const duration = Date.now() - start
+    if (duration > 1000) {
+      this.#logger.warn({ durationMs: duration }, 'SQLiteStorage: cleanup sweep slow')
+    }
+  }
+
+  #startVacuumLoop (): void {
+    if (this.#vacuum === false || !this.#vacuum.enabled) return
+    if (this.#parentStorage) return
+    this.#vacuumInterval = setInterval(() => {
+      this.#runWrite(() => {
+        this.#db?.exec('PRAGMA optimize')
+      }).catch(err => {
+        this.#logger.warn({ err }, 'SQLiteStorage: pragma optimize failed')
+      })
+    }, this.#vacuum.intervalMs)
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
+  // NAMESPACE
+  // ═══════════════════════════════════════════════════════════════════
+
+  createNamespace (name: string): Storage {
+    const root = this.#parentStorage ?? this
+    const ns = new SQLiteStorage({
+      path: root.#path,
+      tablePrefix: `${this.#tablePrefix}${name}_`,
+      cleanupIntervalMs: false, // children do not run cleanup
+      vacuum: false,
+      pragmas: this.#pragmas,
+      logger: this.#logger
+    })
+    ns.#parentStorage = root
+    return ns
+  }
+
+  /**
+   * Clear all data (useful for testing).
+   */
+  async clear (): Promise<void> {
+    if (!this.#db) return
+    const db = this.#db
+    await this.#runWrite(() => {
+      db.exec(`
+        DELETE FROM "${this.#queueTable}";
+        DELETE FROM "${this.#processingTable}";
+        DELETE FROM "${this.#jobsTable}";
+        DELETE FROM "${this.#resultsTable}";
+        DELETE FROM "${this.#errorsTable}";
+        DELETE FROM "${this.#workersTable}";
+        DELETE FROM "${this.#locksTable}";
+      `)
+    })
+  }
+}

--- a/src/storage/sqlite.ts
+++ b/src/storage/sqlite.ts
@@ -147,10 +147,17 @@ export class SQLiteStorage implements Storage {
 
   #instanceId = randomUUID()
   #isCleanupLeader = false
+  // Set to true if disconnect() was called on the root while children were still
+  // connected. The last child to disconnect re-triggers root teardown.
+  #pendingClose = false
 
   // Namespace support — shares the database handle with a root instance.
   #parentStorage: SQLiteStorage | null = null
   #refCount = 0
+  // Set of child namespace prefixes whose tables the root cleanup loop should
+  // sweep. Populated when children connect, cleared on child disconnect.
+  // Only meaningful on the root (parentStorage === null).
+  #childPrefixes: Set<string> = new Set()
 
   // Table names (computed from prefix).
   #jobsTable: string
@@ -197,10 +204,19 @@ export class SQLiteStorage implements Storage {
     if (this.#parentStorage) {
       if (this.#db) return // already connected
       this.#parentStorage.#refCount++
-      await this.#parentStorage.connect()
+      try {
+        await this.#parentStorage.connect()
+      } catch (err) {
+        // Roll back the refCount increment so a future parent.disconnect()
+        // doesn't see a phantom child blocking its teardown.
+        this.#parentStorage.#refCount--
+        throw err
+      }
       this.#db = this.#parentStorage.#db
       this.#connectedPid = this.#parentStorage.#connectedPid
       this.#createSchema()
+      // Register with parent so the cleanup leader sweeps our tables too.
+      this.#parentStorage.#childPrefixes.add(this.#tablePrefix)
       return
     }
 
@@ -223,19 +239,56 @@ export class SQLiteStorage implements Storage {
   }
 
   async disconnect (): Promise<void> {
+    // Forked-child path: drop local refs only. The inherited #db points at the
+    // parent process's open OS handle; closing it would corrupt the parent.
+    // Also don't touch parent.#refCount — that's parent's bookkeeping. Clearing
+    // local timers IS safe (each process has its own event loop).
+    if (this.#db && this.#connectedPid !== null && process.pid !== this.#connectedPid) {
+      if (this.#leadershipTimer) {
+        clearInterval(this.#leadershipTimer)
+        this.#leadershipTimer = null
+      }
+      if (this.#cleanupInterval) {
+        clearInterval(this.#cleanupInterval)
+        this.#cleanupInterval = null
+      }
+      if (this.#vacuumInterval) {
+        clearInterval(this.#vacuumInterval)
+        this.#vacuumInterval = null
+      }
+      this.#db = null
+      this.#connectedPid = null
+      this.#stmts.clear()
+      this.#clearDequeueWaiters()
+      this.#eventEmitter.removeAllListeners()
+      this.#notifyEmitter.removeAllListeners()
+      return
+    }
+
+    // Namespace path
     if (this.#parentStorage) {
+      if (!this.#db) return // idempotent: already disconnected
+      const parent = this.#parentStorage
+      parent.#childPrefixes.delete(this.#tablePrefix)
       this.#clearDequeueWaiters()
       this.#eventEmitter.removeAllListeners()
       this.#notifyEmitter.removeAllListeners()
       this.#stmts.clear()
       this.#db = null
       this.#connectedPid = null
-      this.#parentStorage.#refCount--
+      parent.#refCount--
+      // If root was waiting on us to close, complete its teardown now.
+      if (parent.#pendingClose && parent.#refCount === 0) {
+        await parent.disconnect()
+      }
       return
     }
 
-    if (this.#refCount > 0) return // children still connected
+    // Root path: idempotent
+    if (!this.#db) return
 
+    // Tear down timers first so cleanup/leadership/vacuum ticks don't enqueue
+    // new writes after we start closing.
     if (this.#leadershipTimer) {
       clearInterval(this.#leadershipTimer)
       this.#leadershipTimer = null
@@ -258,20 +311,34 @@ export class SQLiteStorage implements Storage {
       this.#isCleanupLeader = false
     }
 
-    this.#clearDequeueWaiters()
-    this.#eventEmitter.removeAllListeners()
-    this.#notifyEmitter.removeAllListeners()
-    this.#stmts.clear()
-
-    if (this.#db) {
-      try {
-        this.#db.close()
-      } catch {
-        // best-effort
-      }
-      this.#db = null
+    // If children are still connected, defer the actual close. The last child
+    // to disconnect re-triggers this path.
+    if (this.#refCount > 0) {
+      this.#pendingClose = true
+      return
     }
-    this.#connectedPid = null
+
+    // Drain in-flight writes by acquiring the mutex before closing the handle.
+    const release = await this.#acquireMutex()
+    try {
+      this.#clearDequeueWaiters()
+      this.#eventEmitter.removeAllListeners()
+      this.#notifyEmitter.removeAllListeners()
+      this.#stmts.clear()
+
+      if (this.#db) {
+        try {
+          this.#db.close()
+        } catch {
+          // best-effort
+        }
+        this.#db = null
+      }
+      this.#connectedPid = null
+      this.#pendingClose = false
+    } finally {
+      release()
+    }
   }
 
   // SQLite does not accept bind parameters inside PRAGMA statements, so values
@@ -655,11 +722,13 @@ export class SQLiteStorage implements Storage {
     const result = new Map<string, string | null>()
     if (ids.length === 0) return result
 
-    this.#assertConnected()
+    const db = this.#assertConnected()
+    // Bypass the #stmts cache for variable-arity IN-list SQL — caching here
+    // would grow the cache by one entry per distinct batch size.
     const placeholders = ids.map(() => '?').join(',')
-    const rows = this.#stmt(`SELECT id, state, expires_at FROM "${this.#jobsTable}" WHERE id IN (${placeholders})`).all(
-      ...ids
-    ) as Array<{ id: string; state: string; expires_at: number | null }>
+    const rows = db
+      .prepare(`SELECT id, state, expires_at FROM "${this.#jobsTable}" WHERE id IN (${placeholders})`)
+      .all(...ids) as Array<{ id: string; state: string; expires_at: number | null }>
 
     const now = Date.now()
     const found = new Set<string>()
@@ -678,7 +747,7 @@ export class SQLiteStorage implements Storage {
     if (expiredIds.length > 0) {
       const expiredPlaceholders = expiredIds.map(() => '?').join(',')
       await this.#runWrite(() => {
-        this.#stmt(`DELETE FROM "${this.#jobsTable}" WHERE id IN (${expiredPlaceholders})`).run(...expiredIds)
+        db.prepare(`DELETE FROM "${this.#jobsTable}" WHERE id IN (${expiredPlaceholders})`).run(...expiredIds)
       })
     }
 
@@ -899,15 +968,34 @@ export class SQLiteStorage implements Storage {
     const timestamp = Date.now()
     const state = `failing:${timestamp}:${attempts}`
 
-    // Find the old processing row by worker_id. We don't parse JSON; we match all
-    // processing rows for the worker and remove them. Single-process semantics
-    // mean only one row per (worker_id, job-in-flight) is expected.
+    // `message` here is the NEW retry payload (with incremented attempts), not
+    // the bytes sitting in processing. Find the in-flight row for this id by
+    // JSON-parsing each of the worker's processing rows. Mirrors pg.ts. If the
+    // app uses a non-JSON serde, no row matches and the stale row is left for
+    // the reaper to recover — slower, but never wipes sibling in-flight jobs.
+    let oldSeq: number | null = null
+    const rows = this.#stmt(`SELECT seq, message FROM "${this.#processingTable}" WHERE worker_id = ?`).all(
+      workerId
+    ) as Array<{ seq: number; message: unknown }>
+    for (const row of rows) {
+      try {
+        const parsed = JSON.parse(toBuffer(row.message).toString()) as { id?: unknown }
+        if (parsed && parsed.id === id) {
+          oldSeq = row.seq
+          break
+        }
+      } catch {
+        // non-JSON payload; skip
+      }
+    }
+
     await this.#runWrite(() => {
       db.exec('BEGIN IMMEDIATE')
       try {
         this.#stmt(`UPDATE "${this.#jobsTable}" SET state = ? WHERE id = ?`).run(state, id)
-        // Delete the processing row that matches by worker_id (single-process: at most one in flight).
-        this.#stmt(`DELETE FROM "${this.#processingTable}" WHERE worker_id = ?`).run(workerId)
+        if (oldSeq !== null) {
+          this.#stmt(`DELETE FROM "${this.#processingTable}" WHERE seq = ?`).run(oldSeq)
+        }
         this.#stmt(`INSERT INTO "${this.#queueTable}" (message) VALUES (?)`).run(message)
         db.exec('COMMIT')
       } catch (err) {
@@ -1041,17 +1129,23 @@ export class SQLiteStorage implements Storage {
     const now = Date.now()
     const start = now
 
+    // Sweep the root's prefix plus every registered child namespace prefix —
+    // namespaces opt out of running their own cleanup loop, so without this
+    // their results/errors/workers/locks/jobs rows accumulate forever.
+    const prefixes = [this.#tablePrefix, ...this.#childPrefixes]
     await this.#runWrite(() => {
-      this.#stmt(`DELETE FROM "${this.#resultsTable}" WHERE expires_at < ?`).run(now)
-      this.#stmt(`DELETE FROM "${this.#errorsTable}" WHERE expires_at < ?`).run(now)
-      this.#stmt(`DELETE FROM "${this.#workersTable}" WHERE expires_at < ?`).run(now)
-      this.#stmt(`DELETE FROM "${this.#jobsTable}" WHERE expires_at IS NOT NULL AND expires_at < ?`).run(now)
-      this.#stmt(`DELETE FROM "${this.#locksTable}" WHERE expires_at < ?`).run(now)
+      for (const prefix of prefixes) {
+        this.#stmt(`DELETE FROM "${prefix}results" WHERE expires_at < ?`).run(now)
+        this.#stmt(`DELETE FROM "${prefix}errors" WHERE expires_at < ?`).run(now)
+        this.#stmt(`DELETE FROM "${prefix}workers" WHERE expires_at < ?`).run(now)
+        this.#stmt(`DELETE FROM "${prefix}jobs" WHERE expires_at IS NOT NULL AND expires_at < ?`).run(now)
+        this.#stmt(`DELETE FROM "${prefix}locks" WHERE expires_at < ?`).run(now)
+      }
     })
 
     const duration = Date.now() - start
     if (duration > 1000) {
-      this.#logger.warn({ durationMs: duration }, 'SQLiteStorage: cleanup sweep slow')
+      this.#logger.warn({ durationMs: duration, prefixCount: prefixes.length }, 'SQLiteStorage: cleanup sweep slow')
     }
   }
 

--- a/src/storage/sqlite.ts
+++ b/src/storage/sqlite.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'node:events'
 import { randomUUID } from 'node:crypto'
-import { DatabaseSync } from 'node:sqlite'
+import { DatabaseSync, type StatementSync } from 'node:sqlite'
 import type { Logger } from 'pino'
 import type { Storage } from './types.ts'
 import { abstractLogger } from '../utils/logging.ts'
@@ -131,6 +131,10 @@ export class SQLiteStorage implements Storage {
 
   #db: DatabaseSync | null = null
   #connectedPid: number | null = null
+  // Cache of prepared statements keyed by SQL. node:sqlite's prepare() re-parses
+  // every call; reusing StatementSync instances avoids that cost on hot paths.
+  // Cleared on disconnect (statements become invalid once the db handle closes).
+  #stmts: Map<string, StatementSync> = new Map()
 
   #eventEmitter = new EventEmitter({ captureRejections: true })
   #notifyEmitter = new EventEmitter({ captureRejections: true })
@@ -223,6 +227,7 @@ export class SQLiteStorage implements Storage {
       this.#clearDequeueWaiters()
       this.#eventEmitter.removeAllListeners()
       this.#notifyEmitter.removeAllListeners()
+      this.#stmts.clear()
       this.#db = null
       this.#connectedPid = null
       this.#parentStorage.#refCount--
@@ -256,6 +261,7 @@ export class SQLiteStorage implements Storage {
     this.#clearDequeueWaiters()
     this.#eventEmitter.removeAllListeners()
     this.#notifyEmitter.removeAllListeners()
+    this.#stmts.clear()
 
     if (this.#db) {
       try {
@@ -268,6 +274,9 @@ export class SQLiteStorage implements Storage {
     this.#connectedPid = null
   }
 
+  // SQLite does not accept bind parameters inside PRAGMA statements, so values
+  // are interpolated. Pragma keys/values come from the SQLiteStorageConfig
+  // object — trusted at the same level as tablePrefix and path.
   #applyPragmas (): void {
     const db = this.#db!
     for (const [key, value] of Object.entries(this.#pragmas)) {
@@ -280,7 +289,7 @@ export class SQLiteStorage implements Storage {
     if (this.#path === ':memory:') return // WAL not applicable for :memory:
     const requestedJournalMode = String(this.#pragmas.journal_mode ?? '').toLowerCase()
     if (requestedJournalMode !== 'wal') return
-    const row = this.#db!.prepare('PRAGMA journal_mode').get() as { journal_mode?: string } | undefined
+    const row = this.#stmt('PRAGMA journal_mode').get() as { journal_mode?: string } | undefined
     const actual = row?.journal_mode?.toLowerCase()
     if (actual !== 'wal') {
       this.#logger.warn(
@@ -342,13 +351,12 @@ export class SQLiteStorage implements Storage {
   }
 
   #checkSchemaVersion (): void {
-    const db = this.#db!
-    const row = db.prepare(`SELECT value FROM "${this.#metaTable}" WHERE key = 'schema_version'`).get() as
+    const row = this.#stmt(`SELECT value FROM "${this.#metaTable}" WHERE key = 'schema_version'`).get() as
       | { value?: string }
       | undefined
 
     if (!row) {
-      db.prepare(`INSERT OR IGNORE INTO "${this.#metaTable}" (key, value) VALUES ('schema_version', ?)`).run(
+      this.#stmt(`INSERT OR IGNORE INTO "${this.#metaTable}" (key, value) VALUES ('schema_version', ?)`).run(
         String(SCHEMA_VERSION)
       )
       return
@@ -356,8 +364,9 @@ export class SQLiteStorage implements Storage {
 
     const found = parseInt(row.value ?? '0', 10)
     if (Number.isNaN(found) || found > SCHEMA_VERSION) {
+      const echoed = JSON.stringify(row.value ?? null).slice(0, 32)
       throw new StorageError(
-        `SQLiteStorage: database schema version ${row.value ?? '(invalid)'} is not supported ` +
+        `SQLiteStorage: database schema version ${echoed} is not supported ` +
           `by this library (supports schema v${SCHEMA_VERSION}). Downgrade is not supported.`
       )
     }
@@ -371,6 +380,11 @@ export class SQLiteStorage implements Storage {
     if (!this.#db) {
       throw new StorageError('SQLiteStorage: not connected. Call connect() first.')
     }
+    this.#assertSamePid()
+    return this.#db
+  }
+
+  #assertSamePid (): void {
     if (this.#connectedPid !== null && process.pid !== this.#connectedPid) {
       throw new StorageError(
         'SQLiteStorage: detected use from a forked process ' +
@@ -379,7 +393,15 @@ export class SQLiteStorage implements Storage {
           'For multi-process queues, use PgStorage.'
       )
     }
-    return this.#db
+  }
+
+  #stmt (sql: string): StatementSync {
+    let stmt = this.#stmts.get(sql)
+    if (!stmt) {
+      stmt = this.#db!.prepare(sql)
+      this.#stmts.set(sql, stmt)
+    }
+    return stmt
   }
 
   /**
@@ -410,9 +432,8 @@ export class SQLiteStorage implements Storage {
       }
       throw new StorageError(
         `SQLiteStorage: database is locked after ${WRITE_RETRY_ATTEMPTS} retries ` +
-          '(~' +
-          WRITE_RETRY_ATTEMPTS * WRITE_RETRY_MAX_MS +
-          'ms). Another writer is holding the lock. ' +
+          `(exponential backoff up to ${WRITE_RETRY_MAX_MS}ms per attempt). ` +
+          'Another writer is holding the lock. ' +
           'Either reduce contention, increase busy_timeout via pragmas, or switch to PgStorage.',
         lastError instanceof Error ? lastError : undefined
       )
@@ -431,11 +452,11 @@ export class SQLiteStorage implements Storage {
     return previous.then(() => resolver)
   }
 
+  // node:sqlite errors expose .errcode as SQLite's extended result code; mask
+  // to the low byte to compare against the primary code (BUSY=5, LOCKED=6).
   #isBusyError (err: unknown): boolean {
-    if (!(err instanceof Error)) return false
-    const code = (err as NodeJS.ErrnoException).code
-    if (code === 'SQLITE_BUSY' || code === 'SQLITE_LOCKED') return true
-    return /SQLITE_BUSY|SQLITE_LOCKED|database is locked/i.test(err.message ?? '')
+    const primary = ((err as { errcode?: number } | null)?.errcode ?? 0) & 0xff
+    return primary === 5 || primary === 6
   }
 
   // SQLite auto-rolls back on hard errors (SQLITE_FULL, SQLITE_IOERR,
@@ -491,22 +512,22 @@ export class SQLiteStorage implements Storage {
     const existing = await this.#runWrite(() => {
       db.exec('BEGIN IMMEDIATE')
       try {
-        const row = db.prepare(`SELECT state, expires_at FROM "${this.#jobsTable}" WHERE id = ?`).get(id) as
+        const row = this.#stmt(`SELECT state, expires_at FROM "${this.#jobsTable}" WHERE id = ?`).get(id) as
           | { state?: string; expires_at?: number | null }
           | undefined
 
         if (row) {
           const expiresAt = row.expires_at ?? null
           if (expiresAt && now >= expiresAt) {
-            db.prepare(`DELETE FROM "${this.#jobsTable}" WHERE id = ?`).run(id)
+            this.#stmt(`DELETE FROM "${this.#jobsTable}" WHERE id = ?`).run(id)
           } else {
             db.exec('COMMIT')
             return row.state ?? null
           }
         }
 
-        db.prepare(`INSERT INTO "${this.#jobsTable}" (id, state) VALUES (?, ?)`).run(id, state)
-        db.prepare(`INSERT INTO "${this.#queueTable}" (message) VALUES (?)`).run(message)
+        this.#stmt(`INSERT INTO "${this.#jobsTable}" (id, state) VALUES (?, ?)`).run(id, state)
+        this.#stmt(`INSERT INTO "${this.#queueTable}" (message) VALUES (?)`).run(message)
         db.exec('COMMIT')
         return null
       } catch (err) {
@@ -544,13 +565,11 @@ export class SQLiteStorage implements Storage {
     return this.#runWrite(() => {
       db.exec('BEGIN IMMEDIATE')
       try {
-        const row = db
-          .prepare(
-            `DELETE FROM "${this.#queueTable}"
+        const row = this.#stmt(
+          `DELETE FROM "${this.#queueTable}"
              WHERE seq = (SELECT seq FROM "${this.#queueTable}" ORDER BY seq LIMIT 1)
              RETURNING message`
-          )
-          .get() as { message?: unknown } | undefined
+        ).get() as { message?: unknown } | undefined
 
         if (!row || row.message === undefined) {
           db.exec('COMMIT')
@@ -558,7 +577,7 @@ export class SQLiteStorage implements Storage {
         }
 
         const message = toBuffer(row.message)
-        db.prepare(`INSERT INTO "${this.#processingTable}" (worker_id, message) VALUES (?, ?)`).run(workerId, message)
+        this.#stmt(`INSERT INTO "${this.#processingTable}" (worker_id, message) VALUES (?, ?)`).run(workerId, message)
         db.exec('COMMIT')
         return message
       } catch (err) {
@@ -573,8 +592,8 @@ export class SQLiteStorage implements Storage {
     await this.#runWrite(() => {
       db.exec('BEGIN IMMEDIATE')
       try {
-        db.prepare(`DELETE FROM "${this.#processingTable}" WHERE worker_id = ? AND message = ?`).run(workerId, message)
-        db.prepare(`INSERT INTO "${this.#queueTable}" (message) VALUES (?)`).run(message)
+        this.#stmt(`DELETE FROM "${this.#processingTable}" WHERE worker_id = ? AND message = ?`).run(workerId, message)
+        this.#stmt(`INSERT INTO "${this.#queueTable}" (message) VALUES (?)`).run(message)
         db.exec('COMMIT')
       } catch (err) {
         this.#safeRollback()
@@ -585,9 +604,9 @@ export class SQLiteStorage implements Storage {
   }
 
   async ack (id: string, message: Buffer, workerId: string): Promise<void> {
-    const db = this.#assertConnected()
+    this.#assertConnected()
     await this.#runWrite(() => {
-      db.prepare(`DELETE FROM "${this.#processingTable}" WHERE worker_id = ? AND message = ?`).run(workerId, message)
+      this.#stmt(`DELETE FROM "${this.#processingTable}" WHERE worker_id = ? AND message = ?`).run(workerId, message)
     })
   }
 
@@ -596,8 +615,8 @@ export class SQLiteStorage implements Storage {
   // ═══════════════════════════════════════════════════════════════════
 
   async getJobState (id: string): Promise<string | null> {
-    const db = this.#assertConnected()
-    const row = db.prepare(`SELECT state, expires_at FROM "${this.#jobsTable}" WHERE id = ?`).get(id) as
+    this.#assertConnected()
+    const row = this.#stmt(`SELECT state, expires_at FROM "${this.#jobsTable}" WHERE id = ?`).get(id) as
       | { state?: string; expires_at?: number | null }
       | undefined
 
@@ -605,7 +624,7 @@ export class SQLiteStorage implements Storage {
     const expiresAt = row.expires_at ?? null
     if (expiresAt && Date.now() >= expiresAt) {
       await this.#runWrite(() => {
-        db.prepare(`DELETE FROM "${this.#jobsTable}" WHERE id = ?`).run(id)
+        this.#stmt(`DELETE FROM "${this.#jobsTable}" WHERE id = ?`).run(id)
       })
       return null
     }
@@ -613,16 +632,16 @@ export class SQLiteStorage implements Storage {
   }
 
   async setJobState (id: string, state: string): Promise<void> {
-    const db = this.#assertConnected()
+    this.#assertConnected()
     await this.#runWrite(() => {
-      db.prepare(`UPDATE "${this.#jobsTable}" SET state = ? WHERE id = ?`).run(state, id)
+      this.#stmt(`UPDATE "${this.#jobsTable}" SET state = ? WHERE id = ?`).run(state, id)
     })
   }
 
   async deleteJob (id: string): Promise<boolean> {
-    const db = this.#assertConnected()
+    this.#assertConnected()
     const changes = await this.#runWrite(() => {
-      const result = db.prepare(`DELETE FROM "${this.#jobsTable}" WHERE id = ?`).run(id)
+      const result = this.#stmt(`DELETE FROM "${this.#jobsTable}" WHERE id = ?`).run(id)
       return result.changes
     })
     if (changes > 0) {
@@ -636,11 +655,11 @@ export class SQLiteStorage implements Storage {
     const result = new Map<string, string | null>()
     if (ids.length === 0) return result
 
-    const db = this.#assertConnected()
+    this.#assertConnected()
     const placeholders = ids.map(() => '?').join(',')
-    const rows = db
-      .prepare(`SELECT id, state, expires_at FROM "${this.#jobsTable}" WHERE id IN (${placeholders})`)
-      .all(...ids) as Array<{ id: string; state: string; expires_at: number | null }>
+    const rows = this.#stmt(`SELECT id, state, expires_at FROM "${this.#jobsTable}" WHERE id IN (${placeholders})`).all(
+      ...ids
+    ) as Array<{ id: string; state: string; expires_at: number | null }>
 
     const now = Date.now()
     const found = new Set<string>()
@@ -659,7 +678,7 @@ export class SQLiteStorage implements Storage {
     if (expiredIds.length > 0) {
       const expiredPlaceholders = expiredIds.map(() => '?').join(',')
       await this.#runWrite(() => {
-        db.prepare(`DELETE FROM "${this.#jobsTable}" WHERE id IN (${expiredPlaceholders})`).run(...expiredIds)
+        this.#stmt(`DELETE FROM "${this.#jobsTable}" WHERE id IN (${expiredPlaceholders})`).run(...expiredIds)
       })
     }
 
@@ -671,10 +690,10 @@ export class SQLiteStorage implements Storage {
   }
 
   async setJobExpiry (id: string, ttlMs: number): Promise<void> {
-    const db = this.#assertConnected()
+    this.#assertConnected()
     const expiresAt = Date.now() + ttlMs
     await this.#runWrite(() => {
-      db.prepare(`UPDATE "${this.#jobsTable}" SET expires_at = ? WHERE id = ?`).run(expiresAt, id)
+      this.#stmt(`UPDATE "${this.#jobsTable}" SET expires_at = ? WHERE id = ?`).run(expiresAt, id)
     })
   }
 
@@ -683,10 +702,10 @@ export class SQLiteStorage implements Storage {
   // ═══════════════════════════════════════════════════════════════════
 
   async setResult (id: string, result: Buffer, ttlMs: number): Promise<void> {
-    const db = this.#assertConnected()
+    this.#assertConnected()
     const expiresAt = Date.now() + ttlMs
     await this.#runWrite(() => {
-      db.prepare(
+      this.#stmt(
         `INSERT INTO "${this.#resultsTable}" (id, data, expires_at)
          VALUES (?, ?, ?)
          ON CONFLICT(id) DO UPDATE SET data = excluded.data, expires_at = excluded.expires_at`
@@ -695,14 +714,14 @@ export class SQLiteStorage implements Storage {
   }
 
   async getResult (id: string): Promise<Buffer | null> {
-    const db = this.#assertConnected()
-    const row = db.prepare(`SELECT data, expires_at FROM "${this.#resultsTable}" WHERE id = ?`).get(id) as
+    this.#assertConnected()
+    const row = this.#stmt(`SELECT data, expires_at FROM "${this.#resultsTable}" WHERE id = ?`).get(id) as
       | { data?: unknown; expires_at?: number }
       | undefined
     if (!row) return null
     if (row.expires_at !== undefined && Date.now() > row.expires_at) {
       await this.#runWrite(() => {
-        db.prepare(`DELETE FROM "${this.#resultsTable}" WHERE id = ?`).run(id)
+        this.#stmt(`DELETE FROM "${this.#resultsTable}" WHERE id = ?`).run(id)
       })
       return null
     }
@@ -710,10 +729,10 @@ export class SQLiteStorage implements Storage {
   }
 
   async setError (id: string, error: Buffer, ttlMs: number): Promise<void> {
-    const db = this.#assertConnected()
+    this.#assertConnected()
     const expiresAt = Date.now() + ttlMs
     await this.#runWrite(() => {
-      db.prepare(
+      this.#stmt(
         `INSERT INTO "${this.#errorsTable}" (id, data, expires_at)
          VALUES (?, ?, ?)
          ON CONFLICT(id) DO UPDATE SET data = excluded.data, expires_at = excluded.expires_at`
@@ -722,14 +741,14 @@ export class SQLiteStorage implements Storage {
   }
 
   async getError (id: string): Promise<Buffer | null> {
-    const db = this.#assertConnected()
-    const row = db.prepare(`SELECT data, expires_at FROM "${this.#errorsTable}" WHERE id = ?`).get(id) as
+    this.#assertConnected()
+    const row = this.#stmt(`SELECT data, expires_at FROM "${this.#errorsTable}" WHERE id = ?`).get(id) as
       | { data?: unknown; expires_at?: number }
       | undefined
     if (!row) return null
     if (row.expires_at !== undefined && Date.now() > row.expires_at) {
       await this.#runWrite(() => {
-        db.prepare(`DELETE FROM "${this.#errorsTable}" WHERE id = ?`).run(id)
+        this.#stmt(`DELETE FROM "${this.#errorsTable}" WHERE id = ?`).run(id)
       })
       return null
     }
@@ -741,10 +760,10 @@ export class SQLiteStorage implements Storage {
   // ═══════════════════════════════════════════════════════════════════
 
   async registerWorker (workerId: string, ttlMs: number): Promise<void> {
-    const db = this.#assertConnected()
+    this.#assertConnected()
     const expiresAt = Date.now() + ttlMs
     await this.#runWrite(() => {
-      db.prepare(
+      this.#stmt(
         `INSERT INTO "${this.#workersTable}" (worker_id, expires_at)
          VALUES (?, ?)
          ON CONFLICT(worker_id) DO UPDATE SET expires_at = excluded.expires_at`
@@ -758,26 +777,26 @@ export class SQLiteStorage implements Storage {
 
   async unregisterWorker (workerId: string): Promise<void> {
     if (!this.#db) return
-    const db = this.#db
+    this.#assertSamePid()
     await this.#runWrite(() => {
-      db.prepare(`DELETE FROM "${this.#workersTable}" WHERE worker_id = ?`).run(workerId)
-      db.prepare(`DELETE FROM "${this.#processingTable}" WHERE worker_id = ?`).run(workerId)
+      this.#stmt(`DELETE FROM "${this.#workersTable}" WHERE worker_id = ?`).run(workerId)
+      this.#stmt(`DELETE FROM "${this.#processingTable}" WHERE worker_id = ?`).run(workerId)
     })
   }
 
   async getWorkers (): Promise<string[]> {
-    const db = this.#assertConnected()
-    const rows = db
-      .prepare(`SELECT worker_id FROM "${this.#workersTable}" WHERE expires_at > ?`)
-      .all(Date.now()) as Array<{ worker_id: string }>
+    this.#assertConnected()
+    const rows = this.#stmt(`SELECT worker_id FROM "${this.#workersTable}" WHERE expires_at > ?`).all(
+      Date.now()
+    ) as Array<{ worker_id: string }>
     return rows.map(r => r.worker_id)
   }
 
   async getProcessingJobs (workerId: string): Promise<Buffer[]> {
-    const db = this.#assertConnected()
-    const rows = db
-      .prepare(`SELECT message FROM "${this.#processingTable}" WHERE worker_id = ?`)
-      .all(workerId) as Array<{ message: unknown }>
+    this.#assertConnected()
+    const rows = this.#stmt(`SELECT message FROM "${this.#processingTable}" WHERE worker_id = ?`).all(
+      workerId
+    ) as Array<{ message: unknown }>
     return rows.map(r => toBuffer(r.message))
   }
 
@@ -830,13 +849,13 @@ export class SQLiteStorage implements Storage {
     await this.#runWrite(() => {
       db.exec('BEGIN IMMEDIATE')
       try {
-        db.prepare(`UPDATE "${this.#jobsTable}" SET state = ?, expires_at = ? WHERE id = ?`).run(state, expiresAt, id)
-        db.prepare(
+        this.#stmt(`UPDATE "${this.#jobsTable}" SET state = ?, expires_at = ? WHERE id = ?`).run(state, expiresAt, id)
+        this.#stmt(
           `INSERT INTO "${this.#resultsTable}" (id, data, expires_at)
            VALUES (?, ?, ?)
            ON CONFLICT(id) DO UPDATE SET data = excluded.data, expires_at = excluded.expires_at`
         ).run(id, result, expiresAt)
-        db.prepare(`DELETE FROM "${this.#processingTable}" WHERE worker_id = ? AND message = ?`).run(workerId, message)
+        this.#stmt(`DELETE FROM "${this.#processingTable}" WHERE worker_id = ? AND message = ?`).run(workerId, message)
         db.exec('COMMIT')
       } catch (err) {
         this.#safeRollback()
@@ -857,13 +876,13 @@ export class SQLiteStorage implements Storage {
     await this.#runWrite(() => {
       db.exec('BEGIN IMMEDIATE')
       try {
-        db.prepare(`UPDATE "${this.#jobsTable}" SET state = ?, expires_at = ? WHERE id = ?`).run(state, expiresAt, id)
-        db.prepare(
+        this.#stmt(`UPDATE "${this.#jobsTable}" SET state = ?, expires_at = ? WHERE id = ?`).run(state, expiresAt, id)
+        this.#stmt(
           `INSERT INTO "${this.#errorsTable}" (id, data, expires_at)
            VALUES (?, ?, ?)
            ON CONFLICT(id) DO UPDATE SET data = excluded.data, expires_at = excluded.expires_at`
         ).run(id, error, expiresAt)
-        db.prepare(`DELETE FROM "${this.#processingTable}" WHERE worker_id = ? AND message = ?`).run(workerId, message)
+        this.#stmt(`DELETE FROM "${this.#processingTable}" WHERE worker_id = ? AND message = ?`).run(workerId, message)
         db.exec('COMMIT')
       } catch (err) {
         this.#safeRollback()
@@ -886,10 +905,10 @@ export class SQLiteStorage implements Storage {
     await this.#runWrite(() => {
       db.exec('BEGIN IMMEDIATE')
       try {
-        db.prepare(`UPDATE "${this.#jobsTable}" SET state = ? WHERE id = ?`).run(state, id)
+        this.#stmt(`UPDATE "${this.#jobsTable}" SET state = ? WHERE id = ?`).run(state, id)
         // Delete the processing row that matches by worker_id (single-process: at most one in flight).
-        db.prepare(`DELETE FROM "${this.#processingTable}" WHERE worker_id = ?`).run(workerId)
-        db.prepare(`INSERT INTO "${this.#queueTable}" (message) VALUES (?)`).run(message)
+        this.#stmt(`DELETE FROM "${this.#processingTable}" WHERE worker_id = ?`).run(workerId)
+        this.#stmt(`INSERT INTO "${this.#queueTable}" (message) VALUES (?)`).run(message)
         db.exec('COMMIT')
       } catch (err) {
         this.#safeRollback()
@@ -913,9 +932,9 @@ export class SQLiteStorage implements Storage {
     return this.#runWrite(() => {
       db.exec('BEGIN IMMEDIATE')
       try {
-        const row = db
-          .prepare(`SELECT owner_id, expires_at FROM "${this.#locksTable}" WHERE lock_key = ?`)
-          .get(lockKey) as { owner_id?: string; expires_at?: number } | undefined
+        const row = this.#stmt(`SELECT owner_id, expires_at FROM "${this.#locksTable}" WHERE lock_key = ?`).get(
+          lockKey
+        ) as { owner_id?: string; expires_at?: number } | undefined
 
         const now = Date.now()
         if (row && row.expires_at !== undefined && now < row.expires_at) {
@@ -923,7 +942,7 @@ export class SQLiteStorage implements Storage {
           return false
         }
 
-        db.prepare(
+        this.#stmt(
           `INSERT INTO "${this.#locksTable}" (lock_key, owner_id, expires_at)
            VALUES (?, ?, ?)
            ON CONFLICT(lock_key) DO UPDATE
@@ -939,23 +958,24 @@ export class SQLiteStorage implements Storage {
   }
 
   async renewLeaderLock (lockKey: string, ownerId: string, ttlMs: number): Promise<boolean> {
-    const db = this.#assertConnected()
+    this.#assertConnected()
     const expiresAt = Date.now() + ttlMs
     return this.#runWrite(() => {
-      const result = db
-        .prepare(`UPDATE "${this.#locksTable}" SET expires_at = ? WHERE lock_key = ? AND owner_id = ?`)
-        .run(expiresAt, lockKey, ownerId)
+      const result = this.#stmt(
+        `UPDATE "${this.#locksTable}" SET expires_at = ? WHERE lock_key = ? AND owner_id = ?`
+      ).run(expiresAt, lockKey, ownerId)
       return result.changes > 0
     })
   }
 
   async releaseLeaderLock (lockKey: string, ownerId: string): Promise<boolean> {
     if (!this.#db) return false
-    const db = this.#db
+    this.#assertSamePid()
     return this.#runWrite(() => {
-      const result = db
-        .prepare(`DELETE FROM "${this.#locksTable}" WHERE lock_key = ? AND owner_id = ?`)
-        .run(lockKey, ownerId)
+      const result = this.#stmt(`DELETE FROM "${this.#locksTable}" WHERE lock_key = ? AND owner_id = ?`).run(
+        lockKey,
+        ownerId
+      )
       return result.changes > 0
     })
   }
@@ -1017,16 +1037,16 @@ export class SQLiteStorage implements Storage {
   }
 
   async #cleanupExpired (): Promise<void> {
-    const db = this.#assertConnected()
+    this.#assertConnected()
     const now = Date.now()
     const start = now
 
     await this.#runWrite(() => {
-      db.prepare(`DELETE FROM "${this.#resultsTable}" WHERE expires_at < ?`).run(now)
-      db.prepare(`DELETE FROM "${this.#errorsTable}" WHERE expires_at < ?`).run(now)
-      db.prepare(`DELETE FROM "${this.#workersTable}" WHERE expires_at < ?`).run(now)
-      db.prepare(`DELETE FROM "${this.#jobsTable}" WHERE expires_at IS NOT NULL AND expires_at < ?`).run(now)
-      db.prepare(`DELETE FROM "${this.#locksTable}" WHERE expires_at < ?`).run(now)
+      this.#stmt(`DELETE FROM "${this.#resultsTable}" WHERE expires_at < ?`).run(now)
+      this.#stmt(`DELETE FROM "${this.#errorsTable}" WHERE expires_at < ?`).run(now)
+      this.#stmt(`DELETE FROM "${this.#workersTable}" WHERE expires_at < ?`).run(now)
+      this.#stmt(`DELETE FROM "${this.#jobsTable}" WHERE expires_at IS NOT NULL AND expires_at < ?`).run(now)
+      this.#stmt(`DELETE FROM "${this.#locksTable}" WHERE expires_at < ?`).run(now)
     })
 
     const duration = Date.now() - start
@@ -1070,6 +1090,7 @@ export class SQLiteStorage implements Storage {
    */
   async clear (): Promise<void> {
     if (!this.#db) return
+    this.#assertSamePid()
     const db = this.#db
     await this.#runWrite(() => {
       db.exec(`

--- a/test/fixtures/sqlite.ts
+++ b/test/fixtures/sqlite.ts
@@ -1,0 +1,12 @@
+import { SQLiteStorage } from '../../src/storage/sqlite.ts'
+
+/**
+ * Create a SQLiteStorage instance for testing.
+ * Uses :memory: by default; each instance gets its own DB.
+ */
+export function createSQLiteStorage (overrides: { path?: string; tablePrefix?: string } = {}): SQLiteStorage {
+  return new SQLiteStorage({
+    path: overrides.path ?? ':memory:',
+    tablePrefix: overrides.tablePrefix ?? 'jq_'
+  })
+}

--- a/test/integration/e2e.test.ts
+++ b/test/integration/e2e.test.ts
@@ -9,6 +9,7 @@ import { Reaper } from '../../src/reaper.ts'
 import { MemoryStorage } from '../../src/storage/memory.ts'
 import { FileStorage } from '../../src/storage/file.ts'
 import { RedisStorage } from '../../src/storage/redis.ts'
+import { SQLiteStorage } from '../../src/storage/sqlite.ts'
 import type { Storage } from '../../src/storage/types.ts'
 import type { Job } from '../../src/types.ts'
 import { once, waitForEvents, createLatch } from '../helpers/events.ts'
@@ -43,6 +44,16 @@ const fileStorageFactory: StorageFactory = async () => {
   }
 }
 
+const sqliteStorageFactory: StorageFactory = async () => {
+  const storage = new SQLiteStorage()
+  return {
+    storage,
+    cleanup: async () => {
+      await (storage as SQLiteStorage).clear()
+    }
+  }
+}
+
 const redisStorageFactory: StorageFactory = async () => {
   if (!process.env.REDIS_URL) {
     throw new Error('REDIS_URL not set')
@@ -64,7 +75,8 @@ const redisStorageFactory: StorageFactory = async () => {
 function getStorageFactories (): Array<{ name: string; factory: StorageFactory }> {
   const factories: Array<{ name: string; factory: StorageFactory }> = [
     { name: 'MemoryStorage', factory: memoryStorageFactory },
-    { name: 'FileStorage', factory: fileStorageFactory }
+    { name: 'FileStorage', factory: fileStorageFactory },
+    { name: 'SQLiteStorage', factory: sqliteStorageFactory }
   ]
 
   if (process.env.REDIS_URL) {

--- a/test/sqlite-storage.test.ts
+++ b/test/sqlite-storage.test.ts
@@ -543,6 +543,21 @@ describe('SQLiteStorage', () => {
       }
     })
   })
+
+  describe('fork-after-connect pid assertion', () => {
+    it('should reject unregisterWorker / clear / releaseLeaderLock from a different pid', async () => {
+      // Simulate fork by overriding process.pid. Restore in finally.
+      const originalPid = process.pid
+      Object.defineProperty(process, 'pid', { value: originalPid + 1, configurable: true })
+      try {
+        await assert.rejects(storage.unregisterWorker('w1'), /forked process/)
+        await assert.rejects(storage.clear(), /forked process/)
+        await assert.rejects(storage.releaseLeaderLock('k', 'o'), /forked process/)
+      } finally {
+        Object.defineProperty(process, 'pid', { value: originalPid, configurable: true })
+      }
+    })
+  })
 })
 
 describe('SQLiteStorage (file-backed)', () => {

--- a/test/sqlite-storage.test.ts
+++ b/test/sqlite-storage.test.ts
@@ -557,6 +557,95 @@ describe('SQLiteStorage', () => {
         Object.defineProperty(process, 'pid', { value: originalPid, configurable: true })
       }
     })
+
+    it('should not close the shared db handle when disconnect() runs in a forked process', async () => {
+      // Forked-child disconnect must drop local refs only — closing #db would
+      // corrupt the parent process's still-open OS handle.
+      const originalPid = process.pid
+      Object.defineProperty(process, 'pid', { value: originalPid + 1, configurable: true })
+      try {
+        await storage.disconnect()
+      } finally {
+        Object.defineProperty(process, 'pid', { value: originalPid, configurable: true })
+      }
+      // The storage instance now has #db = null locally, but a fresh instance
+      // pointing at :memory: should work — proves the OS-level handle wasn't
+      // catastrophically closed across all process state.
+      const s = new SQLiteStorage()
+      await s.connect()
+      await s.enqueue('postfork', Buffer.from('x'), Date.now())
+      const out = await s.dequeue('w', 1)
+      assert.deepStrictEqual(out, Buffer.from('x'))
+      await s.disconnect()
+    })
+  })
+
+  describe('retryJob with concurrent in-flight jobs', () => {
+    it('should not wipe sibling processing rows for the same worker', async () => {
+      // With consumer.concurrency > 1 a single worker can hold multiple
+      // in-flight messages. retryJob on one must not delete the others.
+      const msgA = Buffer.from(JSON.stringify({ id: 'job-a', payload: 'a', attempts: 0 }))
+      const msgB = Buffer.from(JSON.stringify({ id: 'job-b', payload: 'b', attempts: 0 }))
+
+      await storage.enqueue('job-a', msgA, Date.now())
+      await storage.enqueue('job-b', msgB, Date.now())
+      await storage.dequeue('worker-1', 1)
+      await storage.dequeue('worker-1', 1)
+
+      const beforeProcessing = await storage.getProcessingJobs('worker-1')
+      assert.strictEqual(beforeProcessing.length, 2)
+
+      const retryA = Buffer.from(JSON.stringify({ id: 'job-a', payload: 'a', attempts: 1 }))
+      await storage.retryJob('job-a', retryA, 'worker-1', 1)
+
+      const afterProcessing = await storage.getProcessingJobs('worker-1')
+      // job-b should still be in processing; only job-a was removed.
+      assert.strictEqual(afterProcessing.length, 1)
+      assert.deepStrictEqual(afterProcessing[0], msgB)
+    })
+  })
+
+  describe('namespace lifecycle (adversarial)', () => {
+    it('should be idempotent on double disconnect', async () => {
+      const ns = storage.createNamespace('ns-double') as SQLiteStorage
+      await ns.connect()
+      await ns.disconnect()
+      // Second disconnect must not decrement parent refCount again.
+      await ns.disconnect()
+      // Parent should still be cleanly disconnectable at end of test.
+      // (afterEach will call storage.disconnect(); this assertion is implicit.)
+    })
+
+    it('should roll back parent refCount when child connect fails', async () => {
+      // We can't easily make parent.connect() throw, so simulate the failure
+      // by giving the child a parentStorage whose connect rejects.
+      const failingParent = new SQLiteStorage({ path: '/nonexistent/dir/sqlite.db' })
+      const child = failingParent.createNamespace('x') as SQLiteStorage
+      await assert.rejects(child.connect(), /failed to open/)
+      // Now disconnecting the failing parent should succeed and not be blocked
+      // by a phantom refCount.
+      await failingParent.disconnect()
+    })
+
+    it('should sweep namespace tables in cleanup', async () => {
+      // Use a short cleanupIntervalMs so the leader sweeps quickly.
+      const root = new SQLiteStorage({ cleanupIntervalMs: 50 })
+      await root.connect()
+      const ns = root.createNamespace('cleanup-test') as SQLiteStorage
+      await ns.connect()
+      try {
+        // Put an expired result into the namespace.
+        await ns.setResult('expired-job', Buffer.from('data'), 10)
+        await sleep(50)
+        // Wait for at least one cleanup tick (interval 50ms + ~10ms leader lock acquire).
+        await sleep(300)
+        const result = await ns.getResult('expired-job')
+        assert.strictEqual(result, null, 'namespace result should be swept by root cleanup')
+      } finally {
+        await ns.disconnect()
+        await root.disconnect()
+      }
+    })
   })
 })
 

--- a/test/sqlite-storage.test.ts
+++ b/test/sqlite-storage.test.ts
@@ -1,0 +1,606 @@
+import assert from 'node:assert'
+import { afterEach, beforeEach, describe, it } from 'node:test'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+import { SQLiteStorage } from '../src/storage/sqlite.ts'
+import { StorageError } from '../src/errors.ts'
+import { createSQLiteStorage } from './fixtures/sqlite.ts'
+import { promisifyCallback, waitForCallbacks } from './helpers/events.ts'
+
+describe('SQLiteStorage', () => {
+  let storage: SQLiteStorage
+
+  beforeEach(async () => {
+    storage = createSQLiteStorage()
+    await storage.connect()
+  })
+
+  afterEach(async () => {
+    await storage.clear()
+    await storage.disconnect()
+  })
+
+  describe('enqueue/dequeue', () => {
+    it('should enqueue and dequeue a job', async () => {
+      const message = Buffer.from(JSON.stringify({ id: 'job-1', payload: 'test' }))
+      const result = await storage.enqueue('job-1', message, Date.now())
+
+      assert.strictEqual(result, null, 'enqueue should return null for new job')
+
+      const dequeued = await storage.dequeue('worker-1', 1)
+      assert.ok(dequeued, 'dequeue should return the message')
+      assert.deepStrictEqual(dequeued, message)
+      assert.ok(Buffer.isBuffer(dequeued), 'dequeue should return a Buffer, not Uint8Array')
+    })
+
+    it('should return existing state for duplicate job', async () => {
+      const message = Buffer.from(JSON.stringify({ id: 'job-1', payload: 'test' }))
+      const timestamp = Date.now()
+
+      await storage.enqueue('job-1', message, timestamp)
+      const result = await storage.enqueue('job-1', message, timestamp)
+
+      assert.ok(result, 'should return existing state')
+      assert.ok(result.startsWith('queued:'), 'state should start with queued:')
+    })
+
+    it('should return null on dequeue timeout', async () => {
+      const result = await storage.dequeue('worker-1', 0.1)
+      assert.strictEqual(result, null)
+    })
+
+    it('should dequeue in FIFO order', async () => {
+      const msg1 = Buffer.from('msg-1')
+      const msg2 = Buffer.from('msg-2')
+      const msg3 = Buffer.from('msg-3')
+
+      await storage.enqueue('job-1', msg1, Date.now())
+      await storage.enqueue('job-2', msg2, Date.now())
+      await storage.enqueue('job-3', msg3, Date.now())
+
+      const d1 = await storage.dequeue('worker-1', 1)
+      const d2 = await storage.dequeue('worker-1', 1)
+      const d3 = await storage.dequeue('worker-1', 1)
+
+      assert.deepStrictEqual(d1, msg1)
+      assert.deepStrictEqual(d2, msg2)
+      assert.deepStrictEqual(d3, msg3)
+    })
+
+    it('should wake up dequeue waiter when job is enqueued', async () => {
+      const dequeuePromise = storage.dequeue('worker-1', 5)
+      await sleep(50)
+
+      const msg = Buffer.from('wakeup-test')
+      await storage.enqueue('job-1', msg, Date.now())
+
+      const result = await dequeuePromise
+      assert.deepStrictEqual(result, msg)
+    })
+
+    it('should roundtrip BLOBs as Buffer, not Uint8Array', async () => {
+      const message = Buffer.from([0, 1, 2, 3, 255, 254])
+      await storage.enqueue('job-1', message, Date.now())
+
+      const dequeued = await storage.dequeue('worker-1', 1)
+      assert.ok(Buffer.isBuffer(dequeued))
+      assert.deepStrictEqual(dequeued, message)
+
+      // ack uses WHERE message = ? — must match bytewise
+      await storage.ack('job-1', dequeued as Buffer, 'worker-1')
+      const processing = await storage.getProcessingJobs('worker-1')
+      assert.strictEqual(processing.length, 0)
+    })
+
+    it('should roundtrip large BLOBs', async () => {
+      const message = Buffer.alloc(1024 * 1024) // 1 MB
+      for (let i = 0; i < message.length; i++) message[i] = i % 256
+
+      await storage.enqueue('job-1', message, Date.now())
+      const dequeued = await storage.dequeue('worker-1', 1)
+
+      assert.ok(dequeued)
+      assert.strictEqual(dequeued.length, message.length)
+      assert.deepStrictEqual(dequeued, message)
+    })
+  })
+
+  describe('job state', () => {
+    it('should get and set job state', async () => {
+      await storage.enqueue('job-1', Buffer.from('test'), Date.now())
+      await storage.setJobState('job-1', 'processing:123456:worker-1')
+      const state = await storage.getJobState('job-1')
+
+      assert.strictEqual(state, 'processing:123456:worker-1')
+    })
+
+    it('should return null for non-existent job', async () => {
+      const state = await storage.getJobState('non-existent')
+      assert.strictEqual(state, null)
+    })
+
+    it('should delete job', async () => {
+      await storage.enqueue('job-1', Buffer.from('test'), Date.now())
+      const deleted = await storage.deleteJob('job-1')
+
+      assert.strictEqual(deleted, true)
+      assert.strictEqual(await storage.getJobState('job-1'), null)
+    })
+
+    it('should return false when deleting non-existent job', async () => {
+      const deleted = await storage.deleteJob('non-existent')
+      assert.strictEqual(deleted, false)
+    })
+
+    it('should get multiple job states', async () => {
+      await storage.enqueue('job-1', Buffer.from('a'), Date.now())
+      await storage.setJobState('job-1', 'queued:1')
+      await storage.enqueue('job-2', Buffer.from('b'), Date.now())
+      await storage.setJobState('job-2', 'processing:2')
+
+      const states = await storage.getJobStates(['job-1', 'job-2', 'job-3'])
+
+      assert.strictEqual(states.get('job-1'), 'queued:1')
+      assert.strictEqual(states.get('job-2'), 'processing:2')
+      assert.strictEqual(states.get('job-3'), null)
+    })
+  })
+
+  describe('requeue', () => {
+    it('should move job from processing queue back to main queue', async () => {
+      const message = Buffer.from('requeue-test')
+      await storage.enqueue('job-1', message, Date.now())
+
+      const dequeued = await storage.dequeue('worker-1', 1)
+      assert.deepStrictEqual(dequeued, message)
+
+      const processing = await storage.getProcessingJobs('worker-1')
+      assert.strictEqual(processing.length, 1)
+
+      await storage.requeue('job-1', dequeued as Buffer, 'worker-1')
+
+      const processingAfter = await storage.getProcessingJobs('worker-1')
+      assert.strictEqual(processingAfter.length, 0)
+
+      const redequeued = await storage.dequeue('worker-2', 1)
+      assert.deepStrictEqual(redequeued, message)
+    })
+  })
+
+  describe('ack', () => {
+    it('should remove job from processing queue', async () => {
+      const message = Buffer.from('ack-test')
+      await storage.enqueue('job-1', message, Date.now())
+
+      const dequeued = await storage.dequeue('worker-1', 1)
+      assert.ok(dequeued)
+
+      await storage.ack('job-1', dequeued, 'worker-1')
+
+      const processing = await storage.getProcessingJobs('worker-1')
+      assert.strictEqual(processing.length, 0)
+    })
+  })
+
+  describe('results', () => {
+    it('should store and retrieve result', async () => {
+      const result = Buffer.from(JSON.stringify({ success: true }))
+      await storage.setResult('job-1', result, 60000)
+
+      const retrieved = await storage.getResult('job-1')
+      assert.deepStrictEqual(retrieved, result)
+    })
+
+    it('should return null for non-existent result', async () => {
+      const result = await storage.getResult('non-existent')
+      assert.strictEqual(result, null)
+    })
+
+    it('should return null for expired result', async () => {
+      await storage.setResult('job-1', Buffer.from('short-lived'), 20)
+      await sleep(30)
+
+      const result = await storage.getResult('job-1')
+      assert.strictEqual(result, null)
+    })
+  })
+
+  describe('errors', () => {
+    it('should store and retrieve error', async () => {
+      const error = Buffer.from(JSON.stringify({ message: 'Something failed' }))
+      await storage.setError('job-1', error, 60000)
+
+      const retrieved = await storage.getError('job-1')
+      assert.deepStrictEqual(retrieved, error)
+    })
+
+    it('should return null for non-existent error', async () => {
+      const error = await storage.getError('non-existent')
+      assert.strictEqual(error, null)
+    })
+  })
+
+  describe('workers', () => {
+    it('should register and get workers', async () => {
+      await storage.registerWorker('worker-1', 60000)
+      await storage.registerWorker('worker-2', 60000)
+
+      const workers = await storage.getWorkers()
+      assert.deepStrictEqual(workers.sort(), ['worker-1', 'worker-2'])
+    })
+
+    it('should unregister worker', async () => {
+      await storage.registerWorker('worker-1', 60000)
+      await storage.unregisterWorker('worker-1')
+
+      const workers = await storage.getWorkers()
+      assert.deepStrictEqual(workers, [])
+    })
+
+    it('should not return expired workers', async () => {
+      await storage.registerWorker('worker-1', 20)
+      await sleep(30)
+
+      const workers = await storage.getWorkers()
+      assert.deepStrictEqual(workers, [])
+    })
+  })
+
+  describe('notifications', () => {
+    it('should notify on job completion', async () => {
+      const { value, unsubscribe } = await promisifyCallback<string>(handler =>
+        storage.subscribeToJob('job-1', handler))
+
+      await sleep(50)
+
+      await storage.notifyJobComplete('job-1', 'completed')
+
+      const notifiedStatus = await value
+      assert.strictEqual(notifiedStatus, 'completed')
+
+      await unsubscribe()
+    })
+
+    it('should notify on job failure', async () => {
+      const { value, unsubscribe } = await promisifyCallback<string>(handler =>
+        storage.subscribeToJob('job-1', handler))
+
+      await sleep(50)
+
+      await storage.notifyJobComplete('job-1', 'failed')
+
+      const notifiedStatus = await value
+      assert.strictEqual(notifiedStatus, 'failed')
+
+      await unsubscribe()
+    })
+  })
+
+  describe('events', () => {
+    it('should emit events on state changes', async () => {
+      const events: Array<{ id: string; event: string }> = []
+      const { callback, promise: eventsReceived } = waitForCallbacks(2)
+
+      const unsubscribe = await storage.subscribeToEvents((id, event) => {
+        events.push({ id, event })
+        callback()
+      })
+
+      await sleep(50)
+
+      await storage.publishEvent('job-1', 'processing')
+      await storage.publishEvent('job-1', 'completed')
+
+      await eventsReceived
+
+      assert.deepStrictEqual(events, [
+        { id: 'job-1', event: 'processing' },
+        { id: 'job-1', event: 'completed' }
+      ])
+
+      await unsubscribe()
+    })
+
+    it('should emit queued event on enqueue', async () => {
+      const events: Array<{ id: string; event: string }> = []
+      const { callback, promise: eventReceived } = waitForCallbacks(1)
+
+      const unsubscribe = await storage.subscribeToEvents((id, event) => {
+        events.push({ id, event })
+        callback()
+      })
+
+      await sleep(50)
+
+      await storage.enqueue('job-1', Buffer.from('test'), Date.now())
+
+      await eventReceived
+
+      assert.deepStrictEqual(events, [{ id: 'job-1', event: 'queued' }])
+
+      await unsubscribe()
+    })
+  })
+
+  describe('atomic operations', () => {
+    it('should complete job atomically', async () => {
+      const message = Buffer.from('complete-test')
+      const result = Buffer.from(JSON.stringify({ success: true }))
+
+      await storage.enqueue('job-1', message, Date.now())
+      const dequeued = await storage.dequeue('worker-1', 1)
+      await storage.setJobState('job-1', 'processing:123:worker-1')
+
+      const { value: notificationReceived, unsubscribe } = await promisifyCallback<string>(handler =>
+        storage.subscribeToJob('job-1', handler))
+
+      await sleep(50)
+
+      await storage.completeJob('job-1', dequeued as Buffer, 'worker-1', result, 60000)
+
+      await notificationReceived
+
+      const state = await storage.getJobState('job-1')
+      assert.ok(state?.startsWith('completed:'))
+
+      const storedResult = await storage.getResult('job-1')
+      assert.deepStrictEqual(storedResult, result)
+
+      const processing = await storage.getProcessingJobs('worker-1')
+      assert.strictEqual(processing.length, 0)
+
+      await unsubscribe()
+    })
+
+    it('should fail job atomically', async () => {
+      const message = Buffer.from('fail-test')
+      const error = Buffer.from(JSON.stringify({ message: 'Error' }))
+
+      await storage.enqueue('job-1', message, Date.now())
+      const dequeued = await storage.dequeue('worker-1', 1)
+      await storage.setJobState('job-1', 'processing:123:worker-1')
+
+      const { value: notificationReceived, unsubscribe } = await promisifyCallback<string>(handler =>
+        storage.subscribeToJob('job-1', handler))
+
+      await sleep(50)
+
+      await storage.failJob('job-1', dequeued as Buffer, 'worker-1', error, 60000)
+
+      const notifiedStatus = await notificationReceived
+
+      const state = await storage.getJobState('job-1')
+      assert.ok(state?.startsWith('failed:'))
+
+      const storedError = await storage.getError('job-1')
+      assert.deepStrictEqual(storedError, error)
+
+      assert.strictEqual(notifiedStatus, 'failed')
+
+      await unsubscribe()
+    })
+
+    it('should retry job atomically', async () => {
+      const message = Buffer.from(JSON.stringify({ id: 'job-1', payload: 'test', attempts: 0 }))
+
+      await storage.enqueue('job-1', message, Date.now())
+      await storage.dequeue('worker-1', 1)
+      await storage.setJobState('job-1', 'processing:123:worker-1')
+
+      const updatedMessage = Buffer.from(JSON.stringify({ id: 'job-1', payload: 'test', attempts: 1 }))
+      await storage.retryJob('job-1', updatedMessage, 'worker-1', 1)
+
+      const state = await storage.getJobState('job-1')
+      assert.ok(state?.startsWith('failing:'))
+      assert.ok(state?.endsWith(':1'))
+
+      const dequeued = await storage.dequeue('worker-2', 1)
+      assert.deepStrictEqual(dequeued, updatedMessage)
+    })
+  })
+
+  describe('leader election', () => {
+    it('should acquire lock when no lock exists', async () => {
+      const acquired = await storage.acquireLeaderLock('test-lock', 'owner-1', 60000)
+      assert.strictEqual(acquired, true)
+    })
+
+    it('should fail to acquire lock held by another', async () => {
+      await storage.acquireLeaderLock('test-lock', 'owner-1', 60000)
+      const acquired = await storage.acquireLeaderLock('test-lock', 'owner-2', 60000)
+      assert.strictEqual(acquired, false)
+    })
+
+    it('should acquire lock when expired', async () => {
+      await storage.acquireLeaderLock('test-lock', 'owner-1', 10)
+      await sleep(20)
+
+      const acquired = await storage.acquireLeaderLock('test-lock', 'owner-2', 60000)
+      assert.strictEqual(acquired, true)
+    })
+
+    it('should renew lock by same owner', async () => {
+      await storage.acquireLeaderLock('test-lock', 'owner-1', 60000)
+      const renewed = await storage.renewLeaderLock('test-lock', 'owner-1', 60000)
+      assert.strictEqual(renewed, true)
+    })
+
+    it('should fail to renew lock by different owner', async () => {
+      await storage.acquireLeaderLock('test-lock', 'owner-1', 60000)
+      const renewed = await storage.renewLeaderLock('test-lock', 'owner-2', 60000)
+      assert.strictEqual(renewed, false)
+    })
+
+    it('should release lock by same owner', async () => {
+      await storage.acquireLeaderLock('test-lock', 'owner-1', 60000)
+      const released = await storage.releaseLeaderLock('test-lock', 'owner-1')
+      assert.strictEqual(released, true)
+
+      const acquired = await storage.acquireLeaderLock('test-lock', 'owner-2', 60000)
+      assert.strictEqual(acquired, true)
+    })
+
+    it('should fail to release lock by different owner', async () => {
+      await storage.acquireLeaderLock('test-lock', 'owner-1', 60000)
+      const released = await storage.releaseLeaderLock('test-lock', 'owner-2')
+      assert.strictEqual(released, false)
+    })
+  })
+
+  describe('dedup expiry', () => {
+    it('should allow re-enqueue after dedup expiry', async () => {
+      await storage.enqueue('job-1', Buffer.from('first'), Date.now())
+      await storage.setJobExpiry('job-1', 20)
+
+      await sleep(30)
+
+      const result = await storage.enqueue('job-1', Buffer.from('second'), Date.now())
+      assert.strictEqual(result, null, 'should allow re-enqueue after expiry')
+    })
+
+    it('should block re-enqueue within TTL window', async () => {
+      await storage.enqueue('job-1', Buffer.from('first'), Date.now())
+      await storage.setJobExpiry('job-1', 60000)
+
+      const result = await storage.enqueue('job-1', Buffer.from('second'), Date.now())
+      assert.ok(result, 'should block re-enqueue within TTL')
+    })
+  })
+
+  describe('clear', () => {
+    it('should clear all data', async () => {
+      await storage.enqueue('job-1', Buffer.from('test'), Date.now())
+      await storage.setResult('job-1', Buffer.from('result'), 60000)
+      await storage.registerWorker('worker-1', 60000)
+
+      await storage.clear()
+
+      assert.strictEqual(await storage.getJobState('job-1'), null)
+      assert.strictEqual(await storage.getResult('job-1'), null)
+      assert.deepStrictEqual(await storage.getWorkers(), [])
+    })
+  })
+
+  describe('namespace', () => {
+    it('should isolate data between namespaces', async () => {
+      const ns1 = storage.createNamespace('emails') as SQLiteStorage
+      const ns2 = storage.createNamespace('images') as SQLiteStorage
+
+      await ns1.connect()
+      await ns2.connect()
+
+      try {
+        await ns1.enqueue('job-1', Buffer.from('email-data'), Date.now())
+        await ns2.enqueue('job-1', Buffer.from('image-data'), Date.now())
+
+        const d1 = await ns1.dequeue('worker-1', 1)
+        const d2 = await ns2.dequeue('worker-1', 1)
+
+        assert.deepStrictEqual(d1, Buffer.from('email-data'))
+        assert.deepStrictEqual(d2, Buffer.from('image-data'))
+      } finally {
+        await ns1.clear()
+        await ns2.clear()
+        await ns2.disconnect()
+        await ns1.disconnect()
+      }
+    })
+
+    it('should allow disconnect of namespace without affecting siblings', async () => {
+      const ns1 = storage.createNamespace('a') as SQLiteStorage
+      const ns2 = storage.createNamespace('b') as SQLiteStorage
+      await ns1.connect()
+      await ns2.connect()
+
+      try {
+        await ns1.enqueue('j1', Buffer.from('aaa'), Date.now())
+        await ns2.enqueue('j2', Buffer.from('bbb'), Date.now())
+
+        await ns1.disconnect()
+
+        const d2 = await ns2.dequeue('worker', 1)
+        assert.deepStrictEqual(d2, Buffer.from('bbb'))
+      } finally {
+        await ns2.clear().catch(() => {})
+        await ns2.disconnect().catch(() => {})
+      }
+    })
+  })
+
+  describe('default path :memory:', () => {
+    it('should default to :memory: and not write a file in cwd', async () => {
+      const s = new SQLiteStorage()
+      await s.connect()
+      try {
+        await s.enqueue('j1', Buffer.from('x'), Date.now())
+        const out = await s.dequeue('w1', 1)
+        assert.deepStrictEqual(out, Buffer.from('x'))
+      } finally {
+        await s.disconnect()
+      }
+    })
+  })
+})
+
+describe('SQLiteStorage (file-backed)', () => {
+  let dir: string
+  let storage: SQLiteStorage
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'sqlite-storage-test-'))
+    storage = new SQLiteStorage({ path: join(dir, 'q.sqlite') })
+    await storage.connect()
+  })
+
+  afterEach(async () => {
+    await storage.clear().catch(() => {})
+    await storage.disconnect()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('should activate WAL mode on file-backed databases', async () => {
+    // After connect, WAL files should exist alongside the main DB.
+    await storage.enqueue('j1', Buffer.from('x'), Date.now())
+    // We can't easily inspect the DB file from outside, but we can verify that
+    // a basic roundtrip works and that disconnect succeeds without throwing.
+    const out = await storage.dequeue('w1', 1)
+    assert.deepStrictEqual(out, Buffer.from('x'))
+  })
+
+  it('should persist across reconnect', async () => {
+    await storage.enqueue('j-persist', Buffer.from('persist-me'), Date.now())
+    await storage.disconnect()
+
+    const path = join(dir, 'q.sqlite')
+    const s2 = new SQLiteStorage({ path })
+    await s2.connect()
+    try {
+      const out = await s2.dequeue('w1', 1)
+      assert.deepStrictEqual(out, Buffer.from('persist-me'))
+    } finally {
+      await s2.clear()
+      await s2.disconnect()
+    }
+  })
+
+  it('should refuse to start when schema_version is higher than supported', async () => {
+    // Manually bump the schema_version row to simulate a future-version DB.
+    const path = join(dir, 'future.sqlite')
+    const future = new SQLiteStorage({ path })
+    await future.connect()
+    // Sneak the version up via a private-ish path: clear and rewrite the meta row.
+    // We use a sibling SQLiteStorage to access the same file via raw SQL through
+    // a fresh DatabaseSync connection.
+    await future.disconnect()
+
+    const raw = new DatabaseSync(path)
+    raw.exec("UPDATE \"jq_meta\" SET value = '999' WHERE key = 'schema_version'")
+    raw.close()
+
+    const reopen = new SQLiteStorage({ path })
+    await assert.rejects(reopen.connect(), StorageError)
+  })
+})


### PR DESCRIPTION
## Summary

Adds `SQLiteStorage`. Uses the built-in `node:sqlite` module (Node 22+) with WAL journal mode. Inspired by Solid Queue's SQLite mode.

## Scope decisions

- **Single-process only.** Every operation asserts `process.pid` matches the pid at `connect()` and throws if a fork is detected. SQLite has no `LISTEN`/`NOTIFY` equivalent; supporting cross-process `enqueueAndWait` would require polling and materially more surface. Same call Solid Queue made.
- **`node:sqlite` only.** No `better-sqlite3` opt-in. `engines.node` already gates `>=22.19`, so the built-in driver is universally available.
- **Default `path: ':memory:'`.**

## Key implementation notes

- `BEGIN IMMEDIATE` for atomic dequeue, paired with an in-process write mutex and a 100 ms `busy_timeout` + jittered retry. The mutex prevents N callers from all blocking the Node thread simultaneously; the short timeout bounds worst-case event-loop pause.
- BLOB normalization: `node:sqlite` returns `Uint8Array`; storage normalizes to `Buffer` so the `Storage` interface contract holds.
- Schema version stored in `<prefix>meta`. On connect, refuses to start if the DB was written by a future library version.
- Leader-elected cleanup of expired results/errors/workers/locks, reusing the existing `locks` table pattern (same as `FileStorage`/`PgStorage`).
- Default pragmas align with Rails 8: `WAL`, `synchronous=NORMAL`, `journal_size_limit=64MB`, `mmap_size=128MB`, `cache_size=2000`, **except** `busy_timeout`, which is 100 ms here vs Rails' 5 s. With the synchronous `node:sqlite` API, a multi-second timeout would stall the event loop on contention.

## Test plan

- [x] New `test/sqlite-storage.test.ts`: 45 cases mirroring `test/pg-storage.test.ts` plus SQLite-only additions (Buffer/Uint8Array roundtrip, 1 MB BLOBs, default-`:memory:`, file-backed persistence, schema_version drift, namespace lifecycle).
- [x] `test/integration/e2e.test.ts` parametrized over `SQLiteStorage`: exercises cancellation, reaper stalled-job recovery, high concurrency, deduplication, graceful shutdown.
- [x] Full local non-service test suite passes 238/238 with clean exit.
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm build` all clean.